### PR TITLE
Add SyncCounters example

### DIFF
--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1FDD57E22711563F00066F68 /* SyncCountersExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDD57E12711563F00066F68 /* SyncCountersExample.swift */; };
 		331E1FE126ED20A000719530 /* TestAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331E1FE026ED20A000719530 /* TestAppView.swift */; };
 		332642E726E4056F00438A10 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332642E226E4056F00438A10 /* DemoApp.swift */; };
 		3326431B26E4057D00438A10 /* Root.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332642F226E4057D00438A10 /* Root.swift */; };
@@ -32,6 +33,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1FDD57E12711563F00066F68 /* SyncCountersExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCountersExample.swift; sourceTree = "<group>"; };
 		331E1FE026ED20A000719530 /* TestAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppView.swift; sourceTree = "<group>"; };
 		332642E226E4056F00438A10 /* DemoApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoApp.swift; sourceTree = "<group>"; };
 		332642F226E4057D00438A10 /* Root.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Root.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 				33C8526326ECF13400F3EB94 /* GameOfLifeExample.swift */,
 				339F820F26FA23E3006809CE /* VideoDetectorExample.swift */,
 				33FF25B226FB6C1900E50E27 /* PhysicsExample.swift */,
+				1FDD57E12711563F00066F68 /* SyncCountersExample.swift */,
 			);
 			path = Examples;
 			sourceTree = "<group>";
@@ -246,6 +249,7 @@
 				3326433F26E4094200438A10 /* RootEnvironment.swift in Sources */,
 				3326431C26E4057D00438A10 /* RootView.swift in Sources */,
 				3341066526EC80590032CEDA /* StateDiagramExample.swift in Sources */,
+				1FDD57E22711563F00066F68 /* SyncCountersExample.swift in Sources */,
 				33C8526426ECF13400F3EB94 /* GameOfLifeExample.swift in Sources */,
 				338DC23326FC508500C38587 /* ColorFilterExample.swift in Sources */,
 				3341066326EC80590032CEDA /* GitHubExample.swift in Sources */,

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/AppView.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/AppView.swift
@@ -31,6 +31,7 @@ extension Root.State: RootStateProtocol {}
 
 /// App's initial state to quick start to the target screen (for debugging)
 private let initialRootState: Root.State = .init(
+//    current: .syncCounters(.init()),
 //    current: .physics(.gravityUniverse),
 //    current: .physics(.gravitySurface),
 //    current: .physics(.collision),

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/Root/ExampleList/ExampleList.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/Root/ExampleList/ExampleList.swift
@@ -3,6 +3,7 @@ import Foundation
 @MainActor
 let exampleList: [Example] = [
     CounterExample(),
+    SyncCountersExample(),
     ColorFilterExample(),
     TodoExample(),
     StateDiagramExample(),

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/Root/ExampleList/Examples/SyncCountersExample.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/Root/ExampleList/Examples/SyncCountersExample.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import ActomatonStore
+import SyncCounters
+
+struct SyncCountersExample: Example
+{
+    var exampleIcon: Image { Image(systemName: "goforward.plus") }
+
+    var exampleInitialState: Root.State.Current
+    {
+        .syncCounters(SyncCounters.State())
+    }
+
+    func exampleView(store: Store<Root.Action, Root.State>.Proxy) -> AnyView
+    {
+        Self.exampleView(
+            store: store,
+            actionPath: /Root.Action.syncCounters,
+            statePath: /Root.State.Current.syncCounters,
+            makeView: SyncCountersView.init
+        )
+    }
+}

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/Root/Root.State.Current.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/Root/Root.State.Current.swift
@@ -1,5 +1,6 @@
 import Actomaton
 import Counter
+import SyncCounters
 import ColorFilter
 import Todo
 import StateDiagram
@@ -15,6 +16,7 @@ extension Root.State
     enum Current: Equatable
     {
         case counter(Counter.State)
+        case syncCounters(SyncCounters.State)
         case colorFilter(ColorFilter.State)
         case stopwatch(Stopwatch.State)
         case stateDiagram(StateDiagram.State)
@@ -29,6 +31,7 @@ extension Root.State
         {
             switch self {
             case .counter:          return CounterExample()
+            case .syncCounters:    return SyncCountersExample()
             case .colorFilter:      return ColorFilterExample()
             case .stopwatch:        return StopwatchExample()
             case .stateDiagram:     return StateDiagramExample()

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/Root/Root.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/Root/Root.swift
@@ -1,5 +1,6 @@
 import Actomaton
 import Counter
+import SyncCounters
 import ColorFilter
 import Todo
 import StateDiagram
@@ -21,6 +22,7 @@ extension Root
         case debugToggle(Bool)
 
         case counter(Counter.Action)
+        case syncCounters(SyncCounters.Action)
         case colorFilter(ColorFilter.Action)
         case stopwatch(Stopwatch.Action)
         case stateDiagram(StateDiagram.Action)
@@ -51,6 +53,12 @@ extension Root
                 Counter.reducer
                     .contramap(action: /Action.counter)
                     .contramap(state: /State.Current.counter)
+                    .contramap(state: \State.current)
+                    .contramap(environment: { _ in () }),
+
+                SyncCounters.reducer
+                    .contramap(action: /Action.syncCounters)
+                    .contramap(state: /State.Current.syncCounters)
                     .contramap(state: \State.current)
                     .contramap(environment: { _ in () }),
 

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(
             name: "Gallery",
             targets: [
-                "Counter", "ColorFilter", "Todo", "StateDiagram", "Stopwatch", "GitHub",
+                "Counter", "SyncCounters", "ColorFilter", "Todo", "StateDiagram", "Stopwatch", "GitHub",
                 "GameOfLife", "VideoDetector", "Physics",
                 "TimeTravel", "DebugRoot",
             ])
@@ -42,6 +42,12 @@ let package = Package(
         .target(
             name: "Counter",
             dependencies: [.product(name: "ActomatonStore", package: "Actomaton")]),
+        .target(
+            name: "SyncCounters",
+            dependencies: [
+                .product(name: "ActomatonStore", package: "Actomaton"),
+                "Counter"
+            ]),
         .target(
             name: "ColorFilter",
             dependencies: [

--- a/Sources/Counter/Counter.swift
+++ b/Sources/Counter/Counter.swift
@@ -14,9 +14,12 @@ public enum Action: String, CustomStringConvertible
 
 public struct State: Equatable
 {
-    public var count: Int = 0
+    public var count: Int
 
-    public init() {}
+    public init(count: Int = 0)
+    {
+        self.count = count
+    }
 }
 
 // MARK: - Reducer

--- a/Sources/SyncCounters/SyncCounters.swift
+++ b/Sources/SyncCounters/SyncCounters.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Actomaton
+import Counter
+
+// MARK: - Action
+
+public enum Action
+{
+    case addChild
+    case removeChild
+    case child(Counter.Action)
+}
+
+// MARK: - State
+
+public struct State: Equatable
+{
+    private var _count: Int = 0
+
+    /// Computed getter/setter property to delegate (synchronize) `count` state to children.
+    public var count: Int
+    {
+        get {
+            self._count
+        }
+        set {
+            self._count = newValue
+
+            for i in 0 ..< self.children.count {
+                self.children[i].counterState.count = newValue
+            }
+        }
+    }
+
+    public var children: [CounterState] = [.init(count: 0)]
+
+    public init() {}
+
+    public var canAddChild: Bool
+    {
+        self.children.count < 5
+    }
+
+    public var canRemoveChild: Bool
+    {
+        !self.children.isEmpty
+    }
+
+    // MARK: - CounterState
+
+    public struct CounterState: Hashable, Identifiable
+    {
+        public let id = UUID()
+
+        public var counterState: Counter.State
+
+        public init(count: Int)
+        {
+            self.counterState = .init(count: count)
+        }
+
+        public func hash(into hasher: inout Hasher)
+        {
+            hasher.combine(id)
+        }
+    }
+}
+
+// MARK: - Environment
+
+public typealias Environment = ()
+
+// MARK: - Reducer
+
+public var reducer: Reducer<Action, State, Environment>
+{
+    .init { action, state, _ in
+        switch action {
+        case .addChild:
+            state.children.append(.init(count: state.count))
+            return .empty
+
+        case .removeChild:
+            if !state.children.isEmpty {
+                state.children.removeLast()
+            }
+            return .empty
+
+        case .child(.increment):
+            state.count += 1
+            return .empty
+
+        case .child(.decrement):
+            state.count -= 1
+            return .empty
+        }
+    }
+}

--- a/Sources/SyncCounters/SyncCountersView.swift
+++ b/Sources/SyncCounters/SyncCountersView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import ActomatonStore
+import Counter
+
+public struct SyncCountersView: View
+{
+    private let store: Store<SyncCounters.Action, SyncCounters.State>.Proxy
+
+    public init(store: Store<SyncCounters.Action, SyncCounters.State>.Proxy)
+    {
+        self.store = store
+    }
+
+    public var body: some View
+    {
+        VStack {
+            ForEach(Array(store.state.children.enumerated()), id: \.element) { i, child in
+                let childStore = store.children[i].counterState.contramap(action: SyncCounters.Action.child)
+
+                CounterView(store: childStore)
+                Text("Counter \(i)")
+            }
+
+            Spacer()
+
+            HStack {
+                Spacer()
+
+                Button(action: { store.send(.addChild) }) {
+                    Text("Add")
+                }
+                .disabled(!store.state.canAddChild)
+
+                Spacer(minLength: 20)
+
+                Button(action: { store.send(.removeChild) }) {
+                    Text("Remove")
+                }
+                .disabled(!store.state.canRemoveChild)
+
+                Spacer()
+            }
+            .font(.title)
+        }
+    }
+}
+
+struct SyncCountersView_Previews: PreviewProvider
+{
+    static var previews: some View
+    {
+        SyncCountersView(
+            store: .init(
+                state: .constant(.init()),
+                send: { _ in }
+            )
+        )
+            .previewLayout(.sizeThatFits)
+    }
+}


### PR DESCRIPTION
This PR adds `SyncCounters` example to reuse `Counter` example
and centralize `count` state to transfer across child `Counter`s using get/set computed property.

<img src=https://user-images.githubusercontent.com/138476/136648776-0e5ffed1-e9ea-46ff-903d-876fbb683f7c.png  width=50%>
