### PR TITLE
Add UniversalLink demo

### DIFF
--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1F80CC0C27428A5E001AA7B6 /* Actomaton-Gallery.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Actomaton-Gallery.entitlements"; sourceTree = "<group>"; };
 		331E1FE026ED20A000719530 /* TestAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppView.swift; sourceTree = "<group>"; };
 		332642E226E4056F00438A10 /* DemoApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoApp.swift; sourceTree = "<group>"; };
 		3326433C26E4094200438A10 /* AppView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
@@ -58,6 +59,7 @@
 		33E8F81926E3B374009CC65D /* Actomaton-Gallery */ = {
 			isa = PBXGroup;
 			children = (
+				1F80CC0C27428A5E001AA7B6 /* Actomaton-Gallery.entitlements */,
 				332642E226E4056F00438A10 /* DemoApp.swift */,
 				3326433C26E4094200438A10 /* AppView.swift */,
 				331E1FE026ED20A000719530 /* TestAppView.swift */,
@@ -289,6 +291,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Actomaton-Gallery/Actomaton-Gallery.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -324,6 +327,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Actomaton-Gallery/Actomaton-Gallery.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/Actomaton-Gallery.entitlements
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/Actomaton-Gallery.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:inamiy-universal-link.web.app</string>
+	</array>
+</dict>
+</plist>

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,11 @@ build-SwiftUI-Gallery:
 build-UIKit-Gallery:
 	cd Examples/UIKit-Gallery/ && \
 	xcodebuild build -scheme Actomaton-UIKit-Gallery $(DESTINATION) | xcpretty
+
+# e.g.
+# make universal-link
+# make universal-link path=counter?count=3
+# make universal-link path=physics
+# make universal-link path=physics/gravity-universe  # WARNING: iOS 15 SwiftUI double-push navigation doesn't work well
+universal-link:
+	xcrun simctl openurl booted https://inamiy-universal-link.web.app/$(path)

--- a/Sources/Root/RootView.swift
+++ b/Sources/Root/RootView.swift
@@ -32,6 +32,10 @@ public struct RootView: View
             // https://twitter.com/chriseidhof/status/1441330150872735745
             .navigationViewStyle(.stack)
         }
+        .onOpenURL { url in
+            print("[openURL]", url)
+            store.send(.universalLink(url))
+        }
     }
 
     private func navigationLink(example: Example) -> some View


### PR DESCRIPTION
This PR adds UniversalLink demo using `onOpenURL`.

### Caveat

Due to iOS 15 NavigationView limitation, some dynamic routings can't be safely performed, e.g. 

- From `/` to `/screen1/screen2` that performs **instant double-push**
- From `/screen1` to `/screen2` (screen switching)

### Demo

https://user-images.githubusercontent.com/138476/141795259-74640051-12d2-49a8-bef1-b872e47771a3.mp4

