### PR TITLE
[Physics] Refactor collision algorithms & add LineCollisionExample

### DIFF
--- a/Sources/Physics/ExampleList/ExampleList.swift
+++ b/Sources/Physics/ExampleList/ExampleList.swift
@@ -7,6 +7,7 @@ let worldExampleList: [Example] = [
     SpringExample(),
     SpringPendulumExample(),
     CollisionExample(),
+    LineCollisionExample(),
     GaltonBoardExample(),
 ]
 

--- a/Sources/Physics/ExampleList/Examples/GaltonBoardExample.swift
+++ b/Sources/Physics/ExampleList/Examples/GaltonBoardExample.swift
@@ -41,7 +41,7 @@ struct GaltonBoardExample: Example
 
 extension GaltonBoardExample: ObjectWorldExample
 {
-    func step(objects: inout [Object], boardSize: CGSize)
+    func step(objects: inout [CircleObject], boardSize: CGSize)
     {
         let staticCount = staticObjects.count
         let objectCount = objects.count
@@ -126,14 +126,14 @@ extension GaltonBoardExample: ObjectWorldExample
         }
     }
 
-    func draggingVoid(_ objects: inout [Object], point: CGPoint)
+    func draggingEmptyArea(_ objects: inout [CircleObject], point: CGPoint)
     {
-        objects.append(Object(position: Vector2(point), radius: fallingObjectRadius))
+        objects.append(CircleObject(position: Vector2(point), radius: fallingObjectRadius))
     }
 
-    func exampleTapToMakeObject(point: CGPoint) -> Object?
+    func exampleTapToMakeObject(point: CGPoint) -> CircleObject?
     {
-        Object(position: Vector2(point), radius: fallingObjectRadius)
+        CircleObject(position: Vector2(point), radius: fallingObjectRadius)
     }
 }
 
@@ -147,12 +147,12 @@ private let wallDumping: Scalar = 0.75 // 0.1
 private let staticObjectRadius: Scalar = 6
 private let fallingObjectRadius: Scalar = 4
 
-private let staticObjects: [Object] = {
-    (2 ... 10).flatMap { row -> [Object] in
-        (0 ..< row).map { col -> Object in
+private let staticObjects: [CircleObject] = {
+    (2 ... 10).flatMap { row -> [CircleObject] in
+        (0 ..< row).map { col -> CircleObject in
             let x: Scalar = 180 - staticObjectRadius * 2 * (Scalar(row) - 1) + staticObjectRadius * 4 * Scalar(col)
             let y: Scalar = 100 + staticObjectRadius * 2 * Scalar(row) * sqrt(3)
-            return Object(
+            return CircleObject(
                 mass: 1,
                 position: .init(x, y),
                 velocity: .init(0, 0),
@@ -162,6 +162,6 @@ private let staticObjects: [Object] = {
     }
 }()
 
-private let fallingObjects: [Object] = [
-    Object(mass: 1, position: .init(180 - 1, 0), velocity: .init(0, 0), radius: fallingObjectRadius)
+private let fallingObjects: [CircleObject] = [
+    CircleObject(mass: 1, position: .init(180 - 1, 0), velocity: .init(0, 0), radius: fallingObjectRadius)
 ]

--- a/Sources/Physics/ExampleList/Examples/GravitySurfaceExample.swift
+++ b/Sources/Physics/ExampleList/Examples/GravitySurfaceExample.swift
@@ -9,9 +9,9 @@ struct GravitySurfaceExample: Example
     var exampleInitialState: PhysicsRoot.State.Current
     {
         .gravitySurface(World.State(objects: [
-            Object(mass: 1, position: .init(180, 200), velocity: .init(0, 0)),
-            Object(mass: 1, position: .init(0, 200), velocity: .init(3, -5)),
-            Object(mass: 1, position: .init(0, 200), velocity: .init(3, 0)),
+            CircleObject(mass: 1, position: .init(180, 200), velocity: .init(0, 0)),
+            CircleObject(mass: 1, position: .init(0, 200), velocity: .init(3, -5)),
+            CircleObject(mass: 1, position: .init(0, 200), velocity: .init(3, 0)),
         ]))
     }
 
@@ -44,7 +44,7 @@ struct GravitySurfaceExample: Example
 
 extension GravitySurfaceExample: ObjectWorldExample
 {
-    func step(objects: inout [Object], boardSize: CGSize)
+    func step(objects: inout [CircleObject], boardSize: CGSize)
     {
         // F = m * g
         for i in 0 ..< objects.count {
@@ -53,9 +53,9 @@ extension GravitySurfaceExample: ObjectWorldExample
         }
     }
 
-    func draggingVoid(_ objects: inout [Object], point: CGPoint)
+    func draggingEmptyArea(_ objects: inout [CircleObject], point: CGPoint)
     {
-        objects.append(Object(position: Vector2(point)))
+        objects.append(CircleObject(position: Vector2(point)))
     }
 }
 

--- a/Sources/Physics/ExampleList/Examples/GravityUniverseExample.swift
+++ b/Sources/Physics/ExampleList/Examples/GravityUniverseExample.swift
@@ -8,7 +8,7 @@ struct GravityUniverseExample: Example
 
     var exampleInitialState: PhysicsRoot.State.Current
     {
-        .gravityUniverse(World.State(objects: Object.orbitingObjects))
+        .gravityUniverse(World.State(objects: CircleObject.orbitingObjects))
     }
 
     var exampleArrowScale: ArrowScale
@@ -40,7 +40,7 @@ struct GravityUniverseExample: Example
 
 extension GravityUniverseExample: ObjectWorldExample
 {
-    func step(objects: inout [Object], boardSize: CGSize)
+    func step(objects: inout [CircleObject], boardSize: CGSize)
     {
         let objectCount = objects.count
 

--- a/Sources/Physics/ExampleList/Examples/LineCollisionExample.swift
+++ b/Sources/Physics/ExampleList/Examples/LineCollisionExample.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+import ActomatonStore
+import VectorMath
+
+struct LineCollisionExample: Example
+{
+    var exampleIcon: Image { Image(systemName: "arrow.down.forward.and.arrow.up.backward.circle") }
+
+    var exampleInitialState: PhysicsRoot.State.Current
+    {
+        var objects = CircleObject.collidingObjects.map(Object.circle)
+        objects.append(.line(LineObject(startPosition: Vector2(0, 150), endPosition: Vector2(150, 0))))
+        objects.append(.line(LineObject(startPosition: Vector2(0, 250), endPosition: Vector2(150, 400))))
+        objects.append(.line(LineObject(startPosition: Vector2(250, 0), endPosition: Vector2(400, 150))))
+        objects.append(.line(LineObject(startPosition: Vector2(250, 400), endPosition: Vector2(400, 250))))
+
+        return .lineCollision(World.State(objects: objects))
+    }
+
+    var exampleArrowScale: ArrowScale
+    {
+        // NOTE: Force (impulse) is not simulated in this example.
+        .init(velocityArrowScale: 10, forceArrowScale: 0)
+    }
+
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    {
+        let configuration = store.state.configuration
+
+        return Self.exampleView(
+            store: store,
+            action: PhysicsRoot.Action.lineCollision,
+            statePath: /PhysicsRoot.State.Current.lineCollision,
+            makeView: {
+                WorldView(
+                    store: $0,
+                    configuration: configuration,
+                    absolutePosition: self.absolutePosition,
+                    arrowScale: self.exampleArrowScale
+                )
+            }
+        )
+    }
+}
+
+// MARK: - Algorithm
+
+extension LineCollisionExample: ObjectWorldExample
+{
+    func step(objects: inout [Object], boardSize: CGSize)
+    {
+        let objectCount = objects.count
+
+        for i in 0 ..< objectCount {
+            for j in (i + 1) ..< objects.count {
+                resolveCollision(objects: &objects, at1: i, at2: j)
+            }
+
+            resolveWallCollision(object: &objects[i], boardSize: boardSize)
+        }
+    }
+
+    func draggingEmptyArea(_ objects: inout [Object], point: CGPoint)
+    {
+        switch objects.last {
+        case var .line(line) where !line.isFinalized:
+            line.endPosition = Vector2(point)
+            objects[objects.index(before: objects.endIndex)] = .line(line)
+
+        case .line, .circle, .none:
+            let point = Vector2(point)
+            objects.append(.line(LineObject(startPosition: point, endPosition: point, width: 10, isFinalized: false)))
+        }
+    }
+
+    func dragEndEmptyArea(_ objects: inout [Object])
+    {
+        switch objects.last {
+        case var .line(line):
+            guard !line.isFinalized else { return }
+            line.isFinalized = true
+            objects[objects.index(before: objects.endIndex)] = .line(line)
+
+        case .circle, .none:
+            break
+        }
+    }
+}

--- a/Sources/Physics/ExampleList/Examples/SpringExample.swift
+++ b/Sources/Physics/ExampleList/Examples/SpringExample.swift
@@ -8,7 +8,7 @@ struct SpringExample: Example
 
     var exampleInitialState: PhysicsRoot.State.Current
     {
-        .spring(World.State(objects: Object.orbitingObjects))
+        .spring(World.State(objects: CircleObject.orbitingObjects))
     }
 
     var exampleArrowScale: ArrowScale
@@ -40,7 +40,7 @@ struct SpringExample: Example
 
 extension SpringExample: ObjectWorldExample
 {
-    func step(objects: inout [Object], boardSize: CGSize)
+    func step(objects: inout [CircleObject], boardSize: CGSize)
     {
         let objectCount = objects.count
 

--- a/Sources/Physics/ExampleList/Examples/SpringPendulumExample.swift
+++ b/Sources/Physics/ExampleList/Examples/SpringPendulumExample.swift
@@ -9,7 +9,7 @@ struct SpringPendulumExample: Example
     var exampleInitialState: PhysicsRoot.State.Current
     {
         .springPendulum(World.State(objects: [
-            Object(mass: 1, position: .init(120, 0), velocity: .zero)
+            CircleObject(mass: 1, position: .init(120, 0), velocity: .zero)
         ]))
     }
 
@@ -53,7 +53,7 @@ struct SpringPendulumExample: Example
                         rodPath
                             .stroke(Color.green, lineWidth: 1)
 
-                        WorldView<Object>.makeContentView(
+                        WorldView<CircleObject>.makeContentView(
                             store: store.canvasState,
                             configuration: configuration,
                             absolutePosition: self.absolutePosition,
@@ -73,7 +73,7 @@ struct SpringPendulumExample: Example
 
 extension SpringPendulumExample: ObjectWorldExample
 {
-    func step(objects: inout [Object], boardSize: CGSize)
+    func step(objects: inout [CircleObject], boardSize: CGSize)
     {
         let objectCount = objects.count
 

--- a/Sources/Physics/Helpers/Collision.swift
+++ b/Sources/Physics/Helpers/Collision.swift
@@ -1,0 +1,199 @@
+import Foundation
+import CoreGraphics
+import VectorMath
+
+// MARK: - Manifold
+
+/// Collision manifold as the result of collision detection.
+private struct Manifold
+{
+    /// Depth of penetrated length.
+    var overlap: Scalar
+
+    /// Normal vector of the collision surface.
+    var normal: Vector2
+
+    init(overlap: Scalar, normal: Vector2)
+    {
+        self.overlap = overlap
+        self.normal = normal
+    }
+}
+
+// MARK: - Collision Detection
+
+/// Circle-to-clrcle collision detection.
+private func detectCirclesCollision(circle1: CircleObject, circle2: CircleObject) -> Manifold?
+{
+    let posDiff = circle1.position - circle2.position
+    let posDiffNormal = posDiff.normalized()
+    let overlap = circle1.radius + circle2.radius - posDiff.length
+
+    guard overlap > 0 else { return nil }
+
+    return Manifold(overlap: overlap, normal: posDiffNormal)
+}
+
+/// Line-to-clrcle collision detection.
+private func detectLineCircleCollision(line: LineObject, circle: CircleObject) -> Manifold?
+{
+    let fromCenter = circle.position - line.startPosition
+    let toCenter = circle.position - line.endPosition
+    let fromTo = line.endPosition - line.startPosition
+
+    let innerProd = fromCenter.dot(fromTo)
+
+    if innerProd < 0 {
+        guard pow(circle.radius, 2) > fromCenter.lengthSquared else { return nil }
+        return Manifold(overlap: circle.radius - fromCenter.length, normal: fromCenter.normalized())
+    }
+    else if innerProd > fromTo.lengthSquared {
+        guard pow(circle.radius, 2) > toCenter.lengthSquared else { return nil }
+        return Manifold(overlap: circle.radius - toCenter.length, normal: toCenter.normalized())
+    }
+    else {
+        /// Distance of line and center of the circle.
+        let distance = fromTo.cross(fromCenter) / fromTo.length
+        let overlap = circle.radius - abs(distance) + line.width / 2
+
+        guard overlap > 0 else { return nil }
+
+        if distance >= 0 {
+            // Rotate `fromTo` -90 deg clockwise.
+            return Manifold(overlap: overlap, normal: Vector2(fromTo.y, -fromTo.x).normalized())
+        }
+        else {
+            // Rotate `fromTo` 90 deg clockwise.
+            return Manifold(overlap: overlap, normal: Vector2(-fromTo.y, fromTo.x).normalized())
+        }
+    }
+}
+
+// MARK: - Object Collision Resolution
+
+/// Line-to-clrcle collision detection.
+@discardableResult
+func resolveCircleCollision(circles: inout [CircleObject], at1 i: Int, at2 j: Int) -> Bool
+{
+    let obj = circles[i]
+    let other = circles[j]
+
+    guard let manifold = detectCirclesCollision(circle1: obj, circle2: other) else { return false }
+
+    _resolveCollision(objects: &circles, at1: i, at2: j, manifold: manifold)
+
+    return true
+}
+
+/// Evaluates `manifold` to modify `objects` velocity and position.
+private func _resolveCollision<Obj>(objects: inout [Obj], at1 i: Int, at2 j: Int, manifold: Manifold)
+    where Obj: _ObjectLike
+{
+    let obj1 = objects[i]
+    let obj2 = objects[j]
+
+    let overlap = manifold.overlap
+    let normal = manifold.normal
+
+    let (weightRatio1, weightRatio2) = weightRatios(obj1.mass, obj2.mass)
+
+    // 2-objects collision https://en.wikipedia.org/wiki/Elastic_collision
+    // NOTE: Formula is derived from conservation of kinetic energy and conservation of momentum.
+    let coeff = (obj1.velocity - obj2.velocity).dot(normal) * 2
+
+    objects[i].velocity = obj1.velocity - normal * weightRatio2 * coeff
+    objects[j].velocity = obj2.velocity + normal * weightRatio1 * coeff
+
+    // Sliding
+    objects[i].position = obj1.position + normal * weightRatio2 * overlap
+    objects[j].position = obj2.position - normal * weightRatio1 * overlap
+}
+
+/// Objects collision resolution.
+func resolveCollision(objects: inout [Object], at1 i: Int, at2 j: Int)
+{
+    switch (objects[i], objects[j]) {
+    case let (.circle(circle1), .circle(circle2)):
+        var circles = [circle1, circle2]
+        if resolveCircleCollision(circles: &circles, at1: 0, at2: 1) {
+            objects[i] = .circle(circles[0])
+            objects[j] = .circle(circles[1])
+        }
+
+    case let (.line(line), .circle(circle)):
+        guard let manifold = detectLineCircleCollision(line: line, circle: circle) else { break }
+
+        _resolveCollision(objects: &objects, at1: i, at2: j, manifold: manifold)
+
+    case (.circle, .line):
+        resolveCollision(objects: &objects, at1: j, at2: i)
+
+    default:
+        break
+    }
+}
+
+// MARK: - Wall Collision Resolution
+
+/// Circle-to-wall collision resolution.
+func resolveCircleWallCollision(circle: inout CircleObject, boardSize: CGSize)
+{
+    let restitution: Float = 0.8
+    let friction: Float = 0.0005
+
+    // Flip `velocity.x` if reached at the edge of `canvasSize`.
+    // WARNING: No continuous collision detection.
+    if circle.position.x - circle.radius < 0 {
+        circle.velocity.x = abs(circle.velocity.x) * restitution
+        circle.position.x = circle.radius // sliding
+    }
+    else if circle.position.x + circle.radius > Scalar(boardSize.width) {
+        circle.velocity.x = -abs(circle.velocity.x) * restitution
+        circle.position.x = Scalar(boardSize.width) - circle.radius // sliding
+    }
+
+    // Flip `velocity.y` if reached at the edge of `canvasSize`.
+    if circle.position.y - circle.radius < 0 {
+        circle.velocity.y = abs(circle.velocity.y) * restitution
+        circle.position.y = circle.radius // sliding
+    }
+    else if circle.position.y + circle.radius > Scalar(boardSize.height) {
+        circle.velocity.y = -abs(circle.velocity.y) * restitution
+        circle.position.y = Scalar(boardSize.height) - circle.radius // sliding
+    }
+
+    // Friction as opposite direction of velocity.
+    circle.force = circle.force - circle.velocity.normalized() * friction
+}
+
+/// Object-to-wall collision resolution.
+func resolveWallCollision(object: inout Object, boardSize: CGSize)
+{
+    switch object {
+    case var .circle(circle):
+        resolveCircleWallCollision(circle: &circle, boardSize: boardSize)
+        object = .circle(circle)
+
+    default:
+        break
+    }
+}
+
+// MARK: - Helpers
+
+private func weightRatios(_ mass1: Scalar, _ mass2: Scalar) -> (Scalar, Scalar)
+{
+    switch (mass1.isInfinite, mass2.isInfinite) {
+    case (true, true):
+        return (0.5, 0.5)
+
+    case (true, false):
+        return (1, 0)
+
+    case (false, true):
+        return (0, 1)
+
+    case (false, false):
+        return (mass1 / (mass1 + mass2), mass2 / (mass1 + mass2))
+    }
+}

--- a/Sources/Physics/Helpers/Collision.swift
+++ b/Sources/Physics/Helpers/Collision.swift
@@ -101,12 +101,15 @@ private func _resolveCollision<Obj>(objects: inout [Obj], at1 i: Int, at2 j: Int
     // NOTE: Formula is derived from conservation of kinetic energy and conservation of momentum.
     let coeff = (obj1.velocity - obj2.velocity).dot(normal) * 2
 
-    objects[i].velocity = obj1.velocity - normal * weightRatio2 * coeff
-    objects[j].velocity = obj2.velocity + normal * weightRatio1 * coeff
+    if !obj1.isStatic {
+        objects[i].velocity = obj1.velocity - normal * weightRatio2 * coeff
+        objects[i].position = obj1.position + normal * weightRatio2 * overlap // sliding
+    }
 
-    // Sliding
-    objects[i].position = obj1.position + normal * weightRatio2 * overlap
-    objects[j].position = obj2.position - normal * weightRatio1 * overlap
+    if !obj2.isStatic {
+        objects[j].velocity = obj2.velocity + normal * weightRatio1 * coeff
+        objects[j].position = obj2.position - normal * weightRatio1 * overlap // sliding
+    }
 }
 
 /// Objects collision resolution.

--- a/Sources/Physics/Models/Bob/Bob.swift
+++ b/Sources/Physics/Models/Bob/Bob.swift
@@ -79,6 +79,11 @@ extension Bob: ObjectLike
             )
     }
 
+    public var isStatic: Bool
+    {
+        false
+    }
+
     fileprivate var tangentNorm: Vector2
     {
         position.normalized().rotated(by: -.halfPi)

--- a/Sources/Physics/Models/Bob/Bob.swift
+++ b/Sources/Physics/Models/Bob/Bob.swift
@@ -1,5 +1,4 @@
-import Foundation
-import CoreGraphics
+import SwiftUI
 import VectorMath
 
 /// Pendulum's weight object.
@@ -52,8 +51,17 @@ extension Bob: ObjectLike
         tangentNorm * rodLength * angleAcceleration * mass // mrω'
     }
 
+    public func makeView(absolutePosition: CGPoint) -> some SwiftUI.View
+    {
+        Circle()
+            .position(absolutePosition)
+            .frame(width: visibleRect.width, height: visibleRect.height)
+            .foregroundColor(Color.green)
+            .contrast(1 - 0.2 * log10(Double(mass)))
+    }
+
     /// - Note: Using **relative position** from previous object's position.
-    public var circleRect: CGRect
+    private var visibleRect: CGRect
     {
         let origin = position - Vector2(radius, radius)
         let diameter = radius * 2
@@ -62,12 +70,12 @@ extension Bob: ObjectLike
 
     /// Expands circle's touchable area if too small (at least 28 x 28).
     /// - Note: Using **relative position** from previous object's position. 
-    public var circleTouchRect: CGRect
+    public var touchableRect: CGRect
     {
-        self.circleRect
+        self.visibleRect
             .insetBy(
-                dx: -max(self.circleRect.width / 2, 14),
-                dy: -max(self.circleRect.height / 2, 14)
+                dx: -max(self.visibleRect.width / 2, 14),
+                dy: -max(self.visibleRect.height / 2, 14)
             )
     }
 

--- a/Sources/Physics/Models/Object/CircleObject.swift
+++ b/Sources/Physics/Models/Object/CircleObject.swift
@@ -12,12 +12,15 @@ public struct CircleObject: _ObjectLike, Equatable
 
     public internal(set) var radius: Scalar
 
+    public let isStatic: Bool
+
     public init(
         mass: Mass = 1,
         position: Vector2 = .zero,
         velocity: Vector2 = .zero,
         force: Vector2 = .zero,
-        radius: Scalar = 10
+        radius: Scalar = 10,
+        isStatic: Bool = false
     )
     {
         self.mass = mass
@@ -25,6 +28,7 @@ public struct CircleObject: _ObjectLike, Equatable
         self.velocity = velocity
         self.force = force
         self.radius = radius
+        self.isStatic = isStatic
     }
 
     public func makeView(absolutePosition: CGPoint) -> some SwiftUI.View

--- a/Sources/Physics/Models/Object/CircleObject.swift
+++ b/Sources/Physics/Models/Object/CircleObject.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import VectorMath
+
+public struct CircleObject: _ObjectLike, Equatable
+{
+    public let id: ObjectLikeID = UUID()
+
+    public internal(set) var mass: Mass
+    public internal(set) var position: Vector2
+    public internal(set) var velocity: Vector2
+    public internal(set) var force: Vector2
+
+    public internal(set) var radius: Scalar
+
+    public init(
+        mass: Mass = 1,
+        position: Vector2 = .zero,
+        velocity: Vector2 = .zero,
+        force: Vector2 = .zero,
+        radius: Scalar = 10
+    )
+    {
+        self.mass = mass
+        self.position = position
+        self.velocity = velocity
+        self.force = force
+        self.radius = radius
+    }
+
+    public func makeView(absolutePosition: CGPoint) -> some SwiftUI.View
+    {
+        Circle()
+            .position(absolutePosition)
+            .frame(width: visibleRect.width, height: visibleRect.height)
+            .foregroundColor(Color.green)
+            .contrast(1 - 0.2 * log10(Double(mass)))
+    }
+
+    private var visibleRect: CGRect
+    {
+        let origin = position - Vector2(radius, radius)
+        let diameter = radius * 2
+        return CGRect(x: origin.x, y: origin.y, width: diameter, height: diameter)
+    }
+
+    /// Expands circle's touchable area if too small (at least 28 x 28).
+    public var touchableRect: CGRect
+    {
+        self.visibleRect
+            .insetBy(
+                dx: -max(self.visibleRect.width / 2, 14),
+                dy: -max(self.visibleRect.height / 2, 14)
+            )
+    }
+}

--- a/Sources/Physics/Models/Object/LineObject.swift
+++ b/Sources/Physics/Models/Object/LineObject.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import VectorMath
+
+public struct LineObject: _ObjectLike, Equatable
+{
+    public let id: ObjectLikeID = UUID()
+
+    public internal(set) var startPosition: Vector2
+    public internal(set) var endPosition: Vector2
+    public internal(set) var width: Scalar
+    public internal(set) var isFinalized: Bool
+
+    public init(
+        startPosition: Vector2 = .zero,
+        endPosition: Vector2 = .zero,
+        width: Scalar = 10,
+        isFinalized: Bool = true
+    )
+    {
+        self.startPosition = startPosition
+        self.endPosition = endPosition
+        self.width = width
+        self.isFinalized = isFinalized
+    }
+
+    public var mass: Scalar
+    {
+        get { Scalar.infinity }
+        set {}
+    }
+
+    public var position: Vector2
+    {
+        get { (startPosition + endPosition) / 2 }
+        set {}
+    }
+
+    public var velocity: Vector2
+    {
+        get { .zero }
+        set {}
+    }
+
+    public var force: Vector2
+    {
+        get { .zero }
+        set {}
+    }
+
+    public func makeView(absolutePosition: CGPoint) -> some SwiftUI.View
+    {
+        Path { path in
+            path.move(to: CGPoint(x: startPosition.x, y: startPosition.y))
+            path.addLine(to: CGPoint(x: endPosition.x, y: endPosition.y))
+        }
+        .stroke(lineWidth: CGFloat(width))
+        .fill(Color.red)
+    }
+
+    private var visibleRect: CGRect
+    {
+        .zero
+    }
+
+    public var touchableRect: CGRect
+    {
+        .zero
+    }
+}

--- a/Sources/Physics/Models/Object/LineObject.swift
+++ b/Sources/Physics/Models/Object/LineObject.swift
@@ -66,4 +66,9 @@ public struct LineObject: _ObjectLike, Equatable
     {
         .zero
     }
+
+    public var isStatic: Bool
+    {
+        true
+    }
 }

--- a/Sources/Physics/Models/Object/Object+Presets.swift
+++ b/Sources/Physics/Models/Object/Object+Presets.swift
@@ -1,33 +1,33 @@
 import Darwin
 
 // Presets for initial objects
-extension Object
+extension CircleObject
 {
     // Orbit: v = sqrt(G * M / R)
-    static let orbitingObjects: [Object] = [
-        Object(mass: 1000, position: .init(180, 200), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 + 50, 200), velocity: .init(0, -4.47)),
-        Object(mass: 1, position: .init(180, 200 - 100), velocity: .init(-3.16, 0)),
-        Object(mass: 1, position: .init(180, 200 + 150), velocity: .init(2.58, 0)),
+    static let orbitingObjects: [CircleObject] = [
+        CircleObject(mass: 1000, position: .init(180, 200), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 + 50, 200), velocity: .init(0, -4.47)),
+        CircleObject(mass: 1, position: .init(180, 200 - 100), velocity: .init(-3.16, 0)),
+        CircleObject(mass: 1, position: .init(180, 200 + 150), velocity: .init(2.58, 0)),
     ]
 
     // Like a billiard.
-    static let collidingObjects: [Object] = [
-        Object(mass: 1, position: .init(180, 400), velocity: .init(0, -10)),
-        Object(mass: 1, position: .init(180, 200), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 - 10, 200 - 10 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 + 10, 200 - 10 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 +  0, 200 - 20 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 - 20, 200 - 20 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 + 20, 200 - 20 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 - 10, 200 - 30 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 - 30, 200 - 30 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 + 10, 200 - 30 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 + 30, 200 - 30 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 +  0, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 - 20, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 - 40, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 + 20, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
-        Object(mass: 1, position: .init(180 + 40, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
+    static let collidingObjects: [CircleObject] = [
+        CircleObject(mass: 1, position: .init(180, 400), velocity: .init(0, -10)),
+        CircleObject(mass: 1, position: .init(180, 200), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 - 10, 200 - 10 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 + 10, 200 - 10 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 +  0, 200 - 20 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 - 20, 200 - 20 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 + 20, 200 - 20 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 - 10, 200 - 30 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 - 30, 200 - 30 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 + 10, 200 - 30 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 + 30, 200 - 30 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 +  0, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 - 20, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 - 40, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 + 20, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
+        CircleObject(mass: 1, position: .init(180 + 40, 200 - 40 * sqrt(3)), velocity: .init(0, 0)),
     ]
 }

--- a/Sources/Physics/Models/Object/Object.swift
+++ b/Sources/Physics/Models/Object/Object.swift
@@ -123,4 +123,14 @@ public enum Object: _ObjectLike, Equatable
             return line.touchableRect
         }
     }
+
+    public var isStatic: Bool
+    {
+        switch self {
+        case let .circle(circle):
+            return circle.isStatic
+        case let .line(line):
+            return line.isStatic
+        }
+    }
 }

--- a/Sources/Physics/Models/Object/Object.swift
+++ b/Sources/Physics/Models/Object/Object.swift
@@ -1,54 +1,126 @@
-import Foundation
-import CoreGraphics
+import SwiftUI
 import VectorMath
 
-public struct Object: ObjectLike, Equatable
+public enum Object: _ObjectLike, Equatable
 {
-    public let id: ObjectLikeID = UUID()
+    case circle(CircleObject)
+    case line(LineObject)
 
-    public internal(set) var mass: Mass
-    public internal(set) var position: Vector2
-    public internal(set) var velocity: Vector2
-    public internal(set) var force: Vector2
-
-    public internal(set) var radius: Scalar
-
-    public init(
-        mass: Object.Mass = 1,
-        position: Vector2 = .zero,
-        velocity: Vector2 = .zero,
-        force: Vector2 = .zero,
-        radius: Scalar = 10
-    )
+    public var id: ObjectLikeID
     {
-        self.mass = mass
-        self.position = position
-        self.velocity = velocity
-        self.force = force
-        self.radius = radius
+        switch self {
+        case let .circle(circle):
+            return circle.id
+        case let .line(line):
+            return line.id
+        }
     }
 
-    public var circleRect: CGRect
+    public var mass: Scalar
     {
-        let origin = position - Vector2(radius, radius)
-        let diameter = radius * 2
-        return CGRect(x: origin.x, y: origin.y, width: diameter, height: diameter)
+        get {
+            switch self {
+            case let .circle(circle):
+                return circle.mass
+            case let .line(line):
+                return line.mass
+            }
+        }
+        set {
+            switch self {
+            case var .circle(circle):
+                circle.mass = newValue
+                self = .circle(circle)
+            case var .line(line):
+                line.mass = newValue
+                self = .line(line)
+            }
+        }
     }
 
-    /// Expands circle's touchable area if too small (at least 28 x 28).
-    public var circleTouchRect: CGRect
+    public var position: Vector2
     {
-        self.circleRect
-            .insetBy(
-                dx: -max(self.circleRect.width / 2, 14),
-                dy: -max(self.circleRect.height / 2, 14)
-            )
+        get {
+            switch self {
+            case let .circle(circle):
+                return circle.position
+            case let .line(line):
+                return line.position
+            }
+        }
+        set {
+            switch self {
+            case var .circle(circle):
+                circle.position = newValue
+                self = .circle(circle)
+            case var .line(line):
+                line.position = newValue
+                self = .line(line)
+            }
+        }
     }
-}
 
-// MARK: - Types
+    public var velocity: Vector2
+    {
+        get {
+            switch self {
+            case let .circle(circle):
+                return circle.velocity
+            case let .line(line):
+                return line.velocity
+            }
+        }
+        set {
+            switch self {
+            case var .circle(circle):
+                circle.velocity = newValue
+                self = .circle(circle)
+            case var .line(line):
+                line.velocity = newValue
+                self = .line(line)
+            }
+        }
+    }
 
-extension Object
-{
-    public typealias Mass = Scalar
+    public var force: Vector2
+    {
+        get {
+            switch self {
+            case let .circle(circle):
+                return circle.force
+            case let .line(line):
+                return line.force
+            }
+        }
+        set {
+            switch self {
+            case var .circle(circle):
+                circle.force = newValue
+                self = .circle(circle)
+            case var .line(line):
+                line.force = newValue
+                self = .line(line)
+            }
+        }
+    }
+
+    public func makeView(absolutePosition: CGPoint) -> AnyView
+    {
+        switch self {
+        case let .circle(circle):
+            return AnyView(circle.makeView(absolutePosition: absolutePosition))
+        case let .line(line):
+            return AnyView(line.makeView(absolutePosition: absolutePosition))
+        }
+    }
+
+    public var touchableRect: CGRect
+    {
+        switch self {
+        case let .circle(circle):
+            return circle.touchableRect
+        case let .line(line):
+            return line.touchableRect
+        }
+    }
 }

--- a/Sources/Physics/Models/Object/World+Object.swift
+++ b/Sources/Physics/Models/Object/World+Object.swift
@@ -6,8 +6,9 @@ extension World
 {
     /// Resets `objects` forces, `run` custom logic, and calculates `velocity` & `position`.
     /// - Parameter Δt: Simulated delta time per tick. 
-    static func tickForObjects(_ run: @escaping (inout [Object], _ boardSize: CGSize) -> Void)
-        -> (inout [Object], _ boardSize: CGSize, _ Δt: Scalar) -> Void
+    static func tickForObjects<Obj>(_ run: @escaping (inout [Obj], _ boardSize: CGSize) -> Void)
+        -> (inout [Obj], _ boardSize: CGSize, _ Δt: Scalar) -> Void
+        where Obj: _ObjectLike
     {
         { objects, boardSize, Δt in
             let Δt_ = Scalar(Δt)

--- a/Sources/Physics/PhysicsRoot/PhysicsRoot.State+Presets.swift
+++ b/Sources/Physics/PhysicsRoot/PhysicsRoot.State+Presets.swift
@@ -27,6 +27,11 @@ extension PhysicsRoot.State
         .init(example: CollisionExample())
     }
 
+    public static var lineCollision: PhysicsRoot.State
+    {
+        .init(example: LineCollisionExample())
+    }
+
     public static var galtonBoard: PhysicsRoot.State
     {
         .init(example: GaltonBoardExample())

--- a/Sources/Physics/PhysicsRoot/PhysicsRoot.State.Current.swift
+++ b/Sources/Physics/PhysicsRoot/PhysicsRoot.State.Current.swift
@@ -9,12 +9,13 @@ extension PhysicsRoot.State
     public enum Current: Equatable
     {
         // Object
-        case gravityUniverse(World.State<Object>)
-        case gravitySurface(World.State<Object>)
-        case spring(World.State<Object>)
-        case collision(World.State<Object>)
-        case galtonBoard(World.State<Object>)
-        case springPendulum(World.State<Object>)
+        case gravityUniverse(World.State<CircleObject>)
+        case gravitySurface(World.State<CircleObject>)
+        case spring(World.State<CircleObject>)
+        case collision(World.State<CircleObject>)
+        case lineCollision(World.State<Object>)
+        case galtonBoard(World.State<CircleObject>)
+        case springPendulum(World.State<CircleObject>)
 
         // Pendulum (Bob)
         case pendulum(World.State<Bob>)
@@ -28,6 +29,7 @@ extension PhysicsRoot.State
             case .gravitySurface:   return GravitySurfaceExample()
             case .spring:           return SpringExample()
             case .collision:        return CollisionExample()
+            case .lineCollision:    return LineCollisionExample()
             case .galtonBoard:      return GaltonBoardExample()
             case .springPendulum:   return SpringPendulumExample()
             case .pendulum:         return PendulumExample()
@@ -54,6 +56,10 @@ extension PhysicsRoot.State
             case var .collision(state):
                 state.canvasPlayerState.canvasState.Δt = Δt
                 self = .collision(state)
+
+            case var .lineCollision(state):
+                state.canvasPlayerState.canvasState.Δt = Δt
+                self = .lineCollision(state)
 
             case var .galtonBoard(state):
                 state.canvasPlayerState.canvasState.Δt = Δt

--- a/Sources/Physics/PhysicsRoot/PhysicsRoot.swift
+++ b/Sources/Physics/PhysicsRoot/PhysicsRoot.swift
@@ -21,6 +21,7 @@ extension PhysicsRoot
         case gravitySurface(World.Action)
         case spring(World.Action)
         case collision(World.Action)
+        case lineCollision(World.Action)
         case galtonBoard(World.Action)
         case springPendulum(World.Action)
 
@@ -110,6 +111,11 @@ extension PhysicsRoot
                 CollisionExample().reducer
                     .contramap(action: /Action.collision)
                     .contramap(state: /State.Current.collision)
+                    .contramap(state: \State.current),
+
+                LineCollisionExample().reducer
+                    .contramap(action: /Action.lineCollision)
+                    .contramap(state: /State.Current.lineCollision)
                     .contramap(state: \State.current),
 
                 GaltonBoardExample().reducer

--- a/Sources/Physics/World/ObjectLike.swift
+++ b/Sources/Physics/World/ObjectLike.swift
@@ -19,6 +19,8 @@ public protocol ObjectLike
     func makeView(absolutePosition: CGPoint) -> View
 
     var touchableRect: CGRect { get }
+
+    var isStatic: Bool { get }
 }
 
 protocol _ObjectLike: ObjectLike

--- a/Sources/Physics/World/ObjectLike.swift
+++ b/Sources/Physics/World/ObjectLike.swift
@@ -1,18 +1,33 @@
-import Foundation
-import CoreGraphics
+import SwiftUI
 import VectorMath
 
 public protocol ObjectLike
 {
+    associatedtype View: SwiftUI.View
+
     var id: ObjectLikeID { get }
 
     var mass: Scalar { get }
+
+    /// Center position of the object.
+    /// - Note: This value may be relative to the previous object via `Example.absolutePosition()`.
     var position: Vector2 { get }
+
     var velocity: Vector2 { get }
     var force: Vector2 { get }
 
-    var circleRect: CGRect { get }
-    var circleTouchRect: CGRect { get }
+    func makeView(absolutePosition: CGPoint) -> View
+
+    var touchableRect: CGRect { get }
+}
+
+protocol _ObjectLike: ObjectLike
+{
+    var mass: Scalar { get set }
+    var position: Vector2 { get set }
+    var velocity: Vector2 { get set }
+    var force: Vector2 { get set }
 }
 
 public typealias ObjectLikeID = AnyHashable
+public typealias Mass = Scalar

--- a/Sources/Physics/World/WorldView+Content.swift
+++ b/Sources/Physics/World/WorldView+Content.swift
@@ -97,13 +97,8 @@ extension WorldView
         return ForEach(objects, id: \.object.id) { absObj in
             let obj = absObj.object
             let absPos = absObj.absolutePosition
-            let rect = obj.circleRect
 
-            Circle()
-                .position(CGPoint(absPos + offset))
-                .frame(width: rect.width, height: rect.height)
-                .foregroundColor(Color.green)
-                .contrast(1 - 0.2 * log10(Double(obj.mass)))
+            obj.makeView(absolutePosition: CGPoint(absPos + offset))
         }
     }
 


### PR DESCRIPTION
This PR refactors existing collision algorithms to add new `LineCollisionExample`,
where lines are now part of `Object` that can be placed arbitrarily in the canvas.

<img src=https://user-images.githubusercontent.com/138476/147727147-d8851b70-c691-417a-b2fb-fe41bbeaf9a6.png  width=300>
