### PR TITLE
[SwiftUI] Fix 'Release' build bug by adding additional placeholder enum case for `DebugRoot.Action`

### DIFF
--- a/Sources/DebugRoot/DebugRoot.swift
+++ b/Sources/DebugRoot/DebugRoot.swift
@@ -6,6 +6,13 @@ import TimeTravel
 public enum Action<InnerAction>
 {
     case timeTravel(TimeTravel.Action<InnerAction>)
+
+    #if !DEBUG
+    // Workaround additional `case` for avoiding broken Action in 'Release' build,
+    // which is likely due to Swift compiler bug that optimizes enum case (possibly when single case) in strange way.
+    // https://github.com/inamiy/Actomaton-Gallery/issues/26
+    case doNotUseThis(Never)
+    #endif
 }
 
 // MARK: - State


### PR DESCRIPTION
Bug fix for:
- #26 

This PR fixes #26 by adding extra enum case for `DebugRoot.Action` as a placeholder, which is likely to prevent Swift compiler's (broken) enum optimization and thus avoids its broken value and its warning.

To reproduce this old bug, see e2f2a49 where `Root.Action` is received and then wrapped by `DebugAction.timeTravel(...)` but console-logging inside `contramap` starts to fail when wrapping, printing a broken enum value for some reason only in release build.

This is very strange result by Swift compiler optimization, and because only `Store.Proxy.contramap` is involved in this case, I believe there is no issues in enum reflection i.e. CasePath.