### PR TITLE
Add Actomaton-Favorite-Sync example

### DIFF
--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.pbxproj
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.pbxproj
@@ -1,0 +1,495 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		33110EA8278990D900CF816E /* HUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33110EA7278990D900CF816E /* HUD.swift */; };
+		33110EAB2789B87300CF816E /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33110EA92789B87300CF816E /* DetailView.swift */; };
+		33110EAC2789B87300CF816E /* Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33110EAA2789B87300CF816E /* Detail.swift */; };
+		33110EAE2789B8E400CF816E /* DetailBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33110EAD2789B8E400CF816E /* DetailBuilder.swift */; };
+		333017FA278966EA002A5536 /* Environment.live.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333017F9278966EA002A5536 /* Environment.live.swift */; };
+		333E95D5278C6E2A00792AEE /* CardStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333E95D4278C6E2A00792AEE /* CardStore.swift */; };
+		33D7DA0E278961EC00B362ED /* MyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7DA0D278961EC00B362ED /* MyApp.swift */; };
+		33D7DA12278961ED00B362ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33D7DA11278961ED00B362ED /* Assets.xcassets */; };
+		33D7DA15278961ED00B362ED /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33D7DA14278961ED00B362ED /* Preview Assets.xcassets */; };
+		33D7DA1D2789626500B362ED /* ActomatonStore in Frameworks */ = {isa = PBXBuildFile; productRef = 33D7DA1C2789626500B362ED /* ActomatonStore */; };
+		33D7DA2C2789628100B362ED /* UIKitToSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7DA1E2789628100B362ED /* UIKitToSwiftUI.swift */; };
+		33D7DA2D2789628100B362ED /* FavoriteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7DA202789628100B362ED /* FavoriteStore.swift */; };
+		33D7DA2E2789628100B362ED /* HomeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7DA232789628100B362ED /* HomeBuilder.swift */; };
+		33D7DA2F2789628100B362ED /* FavoriteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7DA252789628100B362ED /* FavoriteBuilder.swift */; };
+		33D7DA302789628100B362ED /* CardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7DA282789628100B362ED /* CardListView.swift */; };
+		33D7DA312789628100B362ED /* CardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7DA292789628100B362ED /* CardList.swift */; };
+		33D7DA322789628100B362ED /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7DA2B2789628100B362ED /* Card.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		33110EA7278990D900CF816E /* HUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUD.swift; sourceTree = "<group>"; };
+		33110EA92789B87300CF816E /* DetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+		33110EAA2789B87300CF816E /* Detail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Detail.swift; sourceTree = "<group>"; };
+		33110EAD2789B8E400CF816E /* DetailBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailBuilder.swift; sourceTree = "<group>"; };
+		333017F9278966EA002A5536 /* Environment.live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.live.swift; sourceTree = "<group>"; };
+		333E95D4278C6E2A00792AEE /* CardStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardStore.swift; sourceTree = "<group>"; };
+		33D7DA0A278961EC00B362ED /* Actomaton-Favorite-Sync.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Actomaton-Favorite-Sync.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33D7DA0D278961EC00B362ED /* MyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyApp.swift; sourceTree = "<group>"; };
+		33D7DA11278961ED00B362ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		33D7DA14278961ED00B362ED /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		33D7DA1E2789628100B362ED /* UIKitToSwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitToSwiftUI.swift; sourceTree = "<group>"; };
+		33D7DA202789628100B362ED /* FavoriteStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteStore.swift; sourceTree = "<group>"; };
+		33D7DA232789628100B362ED /* HomeBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeBuilder.swift; sourceTree = "<group>"; };
+		33D7DA252789628100B362ED /* FavoriteBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteBuilder.swift; sourceTree = "<group>"; };
+		33D7DA282789628100B362ED /* CardListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardListView.swift; sourceTree = "<group>"; };
+		33D7DA292789628100B362ED /* CardList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardList.swift; sourceTree = "<group>"; };
+		33D7DA2B2789628100B362ED /* Card.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		33D7DA07278961EC00B362ED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33D7DA1D2789626500B362ED /* ActomatonStore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		33110EAF2789E15900CF816E /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA1E2789628100B362ED /* UIKitToSwiftUI.swift */,
+				33110EA7278990D900CF816E /* HUD.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		33110EB02789E1DB00CF816E /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA1F2789628100B362ED /* Stores */,
+				33D7DA2A2789628100B362ED /* Models */,
+				33110EAF2789E15900CF816E /* Views */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		33D7DA01278961EC00B362ED = {
+			isa = PBXGroup;
+			children = (
+				33D7DA0C278961EC00B362ED /* Actomaton-Favorite-Sync */,
+				33D7DA0B278961EC00B362ED /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		33D7DA0B278961EC00B362ED /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA0A278961EC00B362ED /* Actomaton-Favorite-Sync.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		33D7DA0C278961EC00B362ED /* Actomaton-Favorite-Sync */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA0D278961EC00B362ED /* MyApp.swift */,
+				333017F9278966EA002A5536 /* Environment.live.swift */,
+				33110EB02789E1DB00CF816E /* Core */,
+				33D7DA212789628100B362ED /* Scenes */,
+				33D7DA11278961ED00B362ED /* Assets.xcassets */,
+				33D7DA13278961ED00B362ED /* Preview Content */,
+			);
+			path = "Actomaton-Favorite-Sync";
+			sourceTree = "<group>";
+		};
+		33D7DA13278961ED00B362ED /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA14278961ED00B362ED /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		33D7DA1F2789628100B362ED /* Stores */ = {
+			isa = PBXGroup;
+			children = (
+				333E95D4278C6E2A00792AEE /* CardStore.swift */,
+				33D7DA202789628100B362ED /* FavoriteStore.swift */,
+			);
+			path = Stores;
+			sourceTree = "<group>";
+		};
+		33D7DA212789628100B362ED /* Scenes */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA222789628100B362ED /* Home */,
+				33D7DA242789628100B362ED /* Favorite */,
+				33D7DA262789628100B362ED /* Detail */,
+				33D7DA272789628100B362ED /* CardList */,
+			);
+			path = Scenes;
+			sourceTree = "<group>";
+		};
+		33D7DA222789628100B362ED /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA232789628100B362ED /* HomeBuilder.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		33D7DA242789628100B362ED /* Favorite */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA252789628100B362ED /* FavoriteBuilder.swift */,
+			);
+			path = Favorite;
+			sourceTree = "<group>";
+		};
+		33D7DA262789628100B362ED /* Detail */ = {
+			isa = PBXGroup;
+			children = (
+				33110EAA2789B87300CF816E /* Detail.swift */,
+				33110EA92789B87300CF816E /* DetailView.swift */,
+				33110EAD2789B8E400CF816E /* DetailBuilder.swift */,
+			);
+			path = Detail;
+			sourceTree = "<group>";
+		};
+		33D7DA272789628100B362ED /* CardList */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA282789628100B362ED /* CardListView.swift */,
+				33D7DA292789628100B362ED /* CardList.swift */,
+			);
+			path = CardList;
+			sourceTree = "<group>";
+		};
+		33D7DA2A2789628100B362ED /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA2B2789628100B362ED /* Card.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		33D7DA09278961EC00B362ED /* Actomaton-Favorite-Sync */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 33D7DA18278961ED00B362ED /* Build configuration list for PBXNativeTarget "Actomaton-Favorite-Sync" */;
+			buildPhases = (
+				33D7DA06278961EC00B362ED /* Sources */,
+				33D7DA07278961EC00B362ED /* Frameworks */,
+				33D7DA08278961EC00B362ED /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Actomaton-Favorite-Sync";
+			packageProductDependencies = (
+				33D7DA1C2789626500B362ED /* ActomatonStore */,
+			);
+			productName = "Actomaton-Favorite-Sync";
+			productReference = 33D7DA0A278961EC00B362ED /* Actomaton-Favorite-Sync.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		33D7DA02278961EC00B362ED /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					33D7DA09278961EC00B362ED = {
+						CreatedOnToolsVersion = 13.2;
+					};
+				};
+			};
+			buildConfigurationList = 33D7DA05278961EC00B362ED /* Build configuration list for PBXProject "Actomaton-Favorite-Sync" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 33D7DA01278961EC00B362ED;
+			packageReferences = (
+				33D7DA1B2789626500B362ED /* XCRemoteSwiftPackageReference "Actomaton" */,
+			);
+			productRefGroup = 33D7DA0B278961EC00B362ED /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				33D7DA09278961EC00B362ED /* Actomaton-Favorite-Sync */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		33D7DA08278961EC00B362ED /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33D7DA15278961ED00B362ED /* Preview Assets.xcassets in Resources */,
+				33D7DA12278961ED00B362ED /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		33D7DA06278961EC00B362ED /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33110EAB2789B87300CF816E /* DetailView.swift in Sources */,
+				33D7DA2F2789628100B362ED /* FavoriteBuilder.swift in Sources */,
+				33110EA8278990D900CF816E /* HUD.swift in Sources */,
+				333017FA278966EA002A5536 /* Environment.live.swift in Sources */,
+				33D7DA2E2789628100B362ED /* HomeBuilder.swift in Sources */,
+				333E95D5278C6E2A00792AEE /* CardStore.swift in Sources */,
+				33D7DA0E278961EC00B362ED /* MyApp.swift in Sources */,
+				33D7DA2C2789628100B362ED /* UIKitToSwiftUI.swift in Sources */,
+				33110EAC2789B87300CF816E /* Detail.swift in Sources */,
+				33D7DA302789628100B362ED /* CardListView.swift in Sources */,
+				33D7DA2D2789628100B362ED /* FavoriteStore.swift in Sources */,
+				33110EAE2789B8E400CF816E /* DetailBuilder.swift in Sources */,
+				33D7DA312789628100B362ED /* CardList.swift in Sources */,
+				33D7DA322789628100B362ED /* Card.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		33D7DA16278961ED00B362ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		33D7DA17278961ED00B362ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		33D7DA19278961ED00B362ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Actomaton-Favorite-Sync/Preview Content\"";
+				DEVELOPMENT_TEAM = UMBZ5WL247;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.Actomaton-Favorite-Sync";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		33D7DA1A278961ED00B362ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Actomaton-Favorite-Sync/Preview Content\"";
+				DEVELOPMENT_TEAM = UMBZ5WL247;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.Actomaton-Favorite-Sync";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		33D7DA05278961EC00B362ED /* Build configuration list for PBXProject "Actomaton-Favorite-Sync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33D7DA16278961ED00B362ED /* Debug */,
+				33D7DA17278961ED00B362ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		33D7DA18278961ED00B362ED /* Build configuration list for PBXNativeTarget "Actomaton-Favorite-Sync" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33D7DA19278961ED00B362ED /* Debug */,
+				33D7DA1A278961ED00B362ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		33D7DA1B2789626500B362ED /* XCRemoteSwiftPackageReference "Actomaton" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/inamiy/Actomaton";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		33D7DA1C2789626500B362ED /* ActomatonStore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 33D7DA1B2789626500B362ED /* XCRemoteSwiftPackageReference "Actomaton" */;
+			productName = ActomatonStore;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 33D7DA02278961EC00B362ED /* Project object */;
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Actomaton",
+        "repositoryURL": "https://github.com/inamiy/Actomaton",
+        "state": {
+          "branch": "main",
+          "revision": "8c57584c2b745c98080a2bd9681dd6fe54eaf7ca",
+          "version": null
+        }
+      },
+      {
+        "package": "swift-case-paths",
+        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
+        "state": {
+          "branch": null,
+          "revision": "241301b67d8551c26d8f09bd2c0e52cc49f18007",
+          "version": "0.8.0"
+        }
+      },
+      {
+        "package": "swift-custom-dump",
+        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
+        "state": {
+          "branch": null,
+          "revision": "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
+          "version": "0.2.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Assets.xcassets/Contents.json
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Models/Card.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Models/Card.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftUI
+
+struct Card: Equatable
+{
+    let id: ID
+    var symbol: String
+    var title: String
+    var description: String
+
+    typealias ID = String
+}
+
+@dynamicMemberLookup
+struct CardWithFavorite: Equatable
+{
+    var card: Card
+    var color: Color
+    var isFavorite: Bool
+
+    var id: Card.ID { card.id }
+
+    subscript<T>(dynamicMember keyPath: WritableKeyPath<Card, T>) -> T
+    {
+        get { card[keyPath: keyPath] }
+        set { card[keyPath: keyPath] = newValue }
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Stores/CardStore.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Stores/CardStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Cards fetcher & caching.
+actor CardStore
+{
+    private var cards: [Card]?
+
+    private var fetchingTask: Task<[Card], Error>?
+
+    func fetchCards(isForced: Bool = false) async throws -> [Card]
+    {
+        if isForced { cards = nil }
+
+        // Use cache if possible.
+        if let cards = cards { return cards }
+
+        // Reuse already fetching task.
+        if let fetchingTask = self.fetchingTask {
+            return try await fetchingTask.value
+        }
+
+        let newFetchingTask = Task<[Card], Error> {
+            // Fake network delay.
+            try await Task.sleep(nanoseconds: 300_000_000)
+
+            // DEBUG: Error test.
+//            struct MyError: Swift.Error {}
+//            throw MyError()
+
+            // Always use built-in faked data (because there is no appropriate endpoint for this demo app).
+            let fetchedCards = Card.fakedFetchedCards
+            return fetchedCards
+        }
+        self.fetchingTask = newFetchingTask
+
+        defer { self.fetchingTask = nil } // NOTE: Called even when `newFetchingTask` fails.
+
+        let fetchedCards = try await newFetchingTask.value
+
+        self.cards = fetchedCards
+
+        return fetchedCards
+    }
+
+    func fetchCard(id: Card.ID) async throws -> Card?
+    {
+        let cards = try await fetchCards()
+        return cards.first(where: { $0.id == id })
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Stores/FavoriteStore.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Stores/FavoriteStore.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Safe Favorites loader using UserDefaults.
+actor FavoriteStore
+{
+    func loadFavorites() -> [String]?
+    {
+        UserDefaults.standard.array(forKey: Self.favoritesKey) as? [String]
+    }
+
+    func loadFavorite(id: Card.ID) -> Bool?
+    {
+        loadFavorites()?.contains(id)
+    }
+
+    func saveFavorites(_ favorites: [String])
+    {
+        UserDefaults.standard.set(favorites, forKey: Self.favoritesKey)
+        UserDefaults.standard.synchronize()
+    }
+
+    func saveFavorite(id: Card.ID, isFavorite: Bool)
+    {
+        var ids = Set(loadFavorites() ?? [])
+
+        switch (isFavorite, ids.contains(id)) {
+        case (false, true):
+            ids.remove(id)
+        case (true, false):
+            ids.insert(id)
+        default:
+            return
+        }
+
+        saveFavorites(Array(ids))
+    }
+
+    private static let favoritesKey = "favorites"
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Views/HUD.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Views/HUD.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@MainActor
+struct HUD<Content: View>: View
+{
+    @ViewBuilder let content: Content
+
+    var body: some View
+    {
+        content
+            .padding(.horizontal, 12)
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 24)
+                    .foregroundColor(Color.white)
+                    .shadow(color: Color(.black).opacity(0.16), radius: 12, x: 0, y: 5)
+            )
+            .padding(16)
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Views/UIKitToSwiftUI.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Core/Views/UIKitToSwiftUI.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import UIKit
+
+/// Conversion from `UIKit.UIView` to `SwiftUI.View`.
+public func uiViewToSwiftUI<V: UIView>(
+    make: (() -> V)? = nil
+) -> some UIViewRepresentable
+{
+    FromUIView(make: make)
+}
+
+/// Conversion from `UIKit.UIViewController` to `SwiftUI.View`.
+public func uiViewControllerToSwiftUI<VC: UIViewController>(
+    make: (() -> VC)? = nil
+) -> some UIViewControllerRepresentable
+{
+    FromUIViewController(make: make)
+}
+
+// MARK: - Private
+
+private struct FromUIView<V: UIView>: UIViewRepresentable
+{
+    let make: (() -> V)?
+
+    init(make: (() -> V)? = nil)
+    {
+        self.make = make
+    }
+
+    func makeUIView(context: Context) -> V
+    {
+        if let make = make {
+            return make()
+        } else {
+            return V()
+        }
+    }
+
+    func updateUIView(_ uiView: V, context: Context) {}
+}
+
+private struct FromUIViewController<VC: UIViewController>: UIViewControllerRepresentable
+{
+    let make: (() -> VC)?
+
+    init(make: (() -> VC)? = nil)
+    {
+        self.make = make
+    }
+
+    func makeUIViewController(context: Context) -> VC
+    {
+        if let make = make {
+            return make()
+        } else {
+            return VC()
+        }
+    }
+
+    func updateUIViewController(_ uiViewController: VC, context: Context) {}
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Environment.live.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Environment.live.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension CardList._Environment
+{
+    static var live: Self
+    {
+        .init(
+            cardStore: CardStore(),
+            favoriteStore: FavoriteStore(),
+            sleep: { 
+                try await Task.sleep(nanoseconds: $0)
+            }
+        )
+    }
+}
+
+extension Card
+{
+    static let fakedFetchedCards = Array(repeating: symbols, count: 10)
+        .flatMap { $0 }
+        .enumerated()
+        .map {
+            Card(id: "\($0)", symbol: $1, title: $1, description: "Description \($1)")
+        }
+}
+
+private let symbols = ["keyboard", "hifispeaker.fill", "printer.fill", "tv.fill", "desktopcomputer", "headphones", "tv.music.note", "mic", "plus.bubble", "video"]

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/MyApp.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/MyApp.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import UIKit
+import ActomatonStore
+
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            uiViewControllerToSwiftUI {
+                let environment = CardList._Environment.live
+
+                let childVCs: [UIViewController] = [
+                    HomeBuilder.buildNavigation(environment: environment),
+                    FavoriteBuilder.buildNavigation(environment: environment)
+                ]
+
+                let tabC = UITabBarController()
+                tabC.setViewControllers(childVCs, animated: false)
+                return tabC
+            }
+            .ignoresSafeArea()
+        }
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/CardList/CardList.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/CardList/CardList.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Actomaton
+import ActomatonStore
+import ActomatonDebugging
+import SwiftUI
+
+/// CardList (namespace).
+enum CardList
+{
+    // MARK: - Action
+
+    enum Action
+    {
+        case loadFavorites
+        case _didLoadFavorites([Card.ID])
+        case _showError(Error)
+        case _hideError
+
+        case fetchCards
+        case _didFetchCards([Card])
+
+        case didTapHeart(Card.ID)
+        case didTapCard(CardWithFavorite)
+    }
+
+    // MARK: - State
+
+    struct State: Equatable
+    {
+        fileprivate var _cards: [Card]
+        fileprivate var favoriteCardIDs: Set<Card.ID>
+        fileprivate var showsFavoriteOnly: Bool
+
+        fileprivate var isFetchingCards: Bool = false
+        fileprivate var isLoadingFavorites: Bool = false
+        fileprivate var errorString: ErrorString?
+
+        init(cards: [Card] = [], favoriteCardIDs: Set<Card.ID> = [], showsFavoriteOnly: Bool)
+        {
+            self._cards = cards
+            self.favoriteCardIDs = favoriteCardIDs
+            self.showsFavoriteOnly = showsFavoriteOnly
+        }
+
+        var cards: [CardWithFavorite]
+        {
+            let colors: [Color] =  [.yellow, .purple, .green]
+
+            let cards = _cards
+                .enumerated()
+                .map { CardWithFavorite(card: $1, color: colors[$0 % colors.count], isFavorite: favoriteCardIDs.contains($1.id)) }
+
+            if showsFavoriteOnly {
+                return cards.filter { $0.isFavorite }
+            }
+            else {
+                return cards
+            }
+        }
+
+        // MARK: - LoadingState
+
+        var loadingState: LoadingState
+        {
+            if let errorString = errorString {
+                return .error(errorString)
+            }
+
+            if (isFetchingCards || isLoadingFavorites) && cards.isEmpty {
+                return .loading
+            }
+
+            return .idle
+        }
+
+        enum LoadingState: Equatable
+        {
+            case idle
+            case loading
+            case error(ErrorString)
+
+            var values: (isLoading: Bool, errorString: ErrorString?)
+            {
+                switch self {
+                case .idle:
+                    return (false, nil)
+                case .loading:
+                    return (true, nil)
+                case let .error(errorString):
+                    return (false, errorString)
+                }
+            }
+        }
+
+        /// Error localizedDescription.
+        /// - Note: Preferred to have Equatable Error.
+        typealias ErrorString = String
+    }
+
+    // MARK: - Route
+
+    enum Route
+    {
+        case showDetail(CardWithFavorite)
+    }
+
+    // MARK: - Environment
+
+    struct _Environment
+    {
+        let cardStore: CardStore
+        let favoriteStore: FavoriteStore
+        let sleep: (_ nanoseconds: UInt64) async throws -> Void
+    }
+
+    typealias Environment = SendRouteEnvironment<_Environment, Route>
+
+    // MARK: - Reducer
+
+    static func reducer() -> Reducer<Action, State, Environment>
+    {
+        .debug(name: "[CardList]") { action, state, env in
+            switch action {
+            case .loadFavorites:
+                state.isLoadingFavorites = true
+
+                return Effect {
+                    if let cardIDs = await env.environment.favoriteStore.loadFavorites() {
+                        return ._didLoadFavorites(cardIDs)
+                    }
+                    else {
+                        return ._showError(Error.failedLoadingFavorites)
+                    }
+                }
+
+            case let ._didLoadFavorites(cardIDs):
+                state.favoriteCardIDs = Set(cardIDs)
+                state.isLoadingFavorites = false
+                return .empty
+
+            case .fetchCards:
+                state.isFetchingCards = true
+
+                return Effect {
+                    if let cards = try? await env.environment.cardStore.fetchCards() {
+                        return ._didFetchCards(cards)
+                    }
+                    else {
+                        return ._showError(Error.failedFetchingCards)
+                    }
+                }
+
+            case let ._didFetchCards(cards):
+                state._cards = cards
+                state.isFetchingCards = false
+                return .empty
+
+            case let .didTapHeart(cardID):
+                if let cardID = state.favoriteCardIDs.firstIndex(of: cardID) {
+                    state.favoriteCardIDs.remove(at: cardID)
+                }
+                else {
+                    state.favoriteCardIDs.insert(cardID)
+                }
+
+                return Effect { [state] in
+                    let cardIDs = Array(state.favoriteCardIDs)
+                    await env.environment.favoriteStore.saveFavorites(cardIDs)
+                    return nil
+                }
+
+            case let .didTapCard(card):
+                env.sendRoute(.showDetail(card))
+                return .empty
+
+            case let ._showError(error):
+                print("===> error", error.localizedDescription)
+                state.errorString = error.localizedDescription
+
+                switch error {
+                case .failedLoadingFavorites:
+                    state.isLoadingFavorites = false
+
+                case .failedFetchingCards:
+                    state.isFetchingCards = false
+                }
+
+                return Effect {
+                    try await env.environment.sleep(2_000_000_000)
+                    return ._hideError
+                }
+
+            case ._hideError:
+                state.errorString = nil
+                return .empty
+            }
+        }
+    }
+
+    // MARK: - Error
+
+    enum Error: Swift.Error
+    {
+        case failedLoadingFavorites
+        case failedFetchingCards
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/CardList/CardListView.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/CardList/CardListView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import ActomatonStore
+
+@MainActor
+struct CardListView: View
+{
+    private let store: Store<Action, State>.Proxy
+
+    init(store: Store<Action, State>.Proxy)
+    {
+        self.store = store
+    }
+
+    var body: some View
+    {
+        let (isLoading, errorString) = store.state.loadingState.values
+
+        ZStack {
+            completedOrEmpty
+                .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity
+                )
+
+            isLoading ? HUD { ProgressView("Loading") } : nil
+
+            errorViewIfNeeded(errorString: errorString)
+                .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity,
+                    alignment: .bottom
+                )
+        }
+        .onAppear {
+            store.send(.loadFavorites)
+            store.send(.fetchCards)
+        }
+    }
+
+    @ViewBuilder
+    var completedOrEmpty: some View
+    {
+        if store.state.cards.isEmpty {
+            emptyView
+        }
+        else {
+            completedView
+        }
+    }
+
+    @ViewBuilder
+    func errorViewIfNeeded(errorString: String?) -> some View
+    {
+        if let errorString = errorString {
+            HUD {
+                Label(errorString, systemImage: "exclamationmark.triangle")
+            }
+        }
+    }
+
+    @ViewBuilder
+    var completedView: some View
+    {
+        ScrollView {
+            let columns = [GridItem(.flexible()), GridItem(.flexible())]
+            let cards = store.state.cards
+
+            LazyVGrid(columns: columns) {
+                ForEach(0 ..< cards.count, id: \.self) { i in
+                    let card = cards[i]
+                    cardView(card: card, at: i)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func cardView(card: CardWithFavorite, at index: Int) -> some View
+    {
+        ZStack(alignment: .topTrailing) {
+            Button {
+                store.send(.didTapCard(card))
+            } label: {
+                Image(systemName: card.symbol)
+                    .font(.system(size: 30))
+                    .frame(width: 150, height: 150)
+                    .background(card.color)
+                    .cornerRadius(10)
+            }
+
+            Button {
+                store.send(.didTapHeart(card.id))
+            } label: {
+                Image(systemName: card.isFavorite ? "heart.fill" : "heart")
+                    .font(.system(size: 30))
+                    .frame(width: 30, height: 30)
+            }
+            .offset(x: -10, y: 10)
+        }
+        .overlay(
+            Text("ID: \(card.id)")
+                .padding(.bottom, 8),
+            alignment: .bottom
+        )
+    }
+
+    @ViewBuilder
+    private var emptyView: some View
+    {
+        Text("No Cards")
+    }
+
+    typealias Action = CardList.Action
+    typealias State = CardList.State
+    typealias Route = CardList.Route
+}
+
+struct CardListView_Previews: PreviewProvider
+{
+    static var previews: some View
+    {
+        CardListView(
+            store: .init(
+                state: .constant(CardList.State(cards: Card.fakedFetchedCards, showsFavoriteOnly: false)),
+                send: { _ in }
+            )
+        )
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/Detail.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/Detail.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Actomaton
+import ActomatonStore
+import ActomatonDebugging
+
+/// Detail (namespace).
+enum Detail
+{
+    // MARK: - Action
+
+    enum Action
+    {
+        case loadFavorite
+        case _didLoadFavorite(Bool)
+        case _showError(Error)
+        case _hideError
+
+        case fetchCard
+        case _didFetchCard(Card)
+
+        case didTapHeart(Card.ID)
+    }
+
+    // MARK: - State
+
+    struct State: Equatable
+    {
+        fileprivate(set) var card: CardWithFavorite
+
+        fileprivate var isFetchingCard: Bool = false
+        fileprivate var isLoadingFavorite: Bool = false
+        fileprivate var errorString: ErrorString?
+
+        init(card: CardWithFavorite)
+        {
+            self.card = card
+        }
+
+        // MARK: - LoadingState
+
+        var loadingState: LoadingState
+        {
+            if let errorString = errorString {
+                return .error(errorString)
+            }
+
+            if isFetchingCard || isLoadingFavorite {
+                return .loading
+            }
+
+            return .complete
+        }
+
+        enum LoadingState: Equatable
+        {
+            case loading
+            case complete
+            case empty
+            case error(ErrorString)
+
+            var values: (isLoading: Bool, errorString: ErrorString?)
+            {
+                switch self {
+                case .loading:
+                    return (true, nil)
+                case .complete:
+                    return (false, nil)
+                case .empty:
+                    return (false, nil)
+                case let .error(errorString):
+                    return (false, errorString)
+                }
+            }
+        }
+
+        /// Error localizedDescription.
+        /// - Note: Preferred to have Equatable Error.
+        typealias ErrorString = String
+    }
+
+    // MARK: - Route
+
+    enum Route
+    {
+    }
+
+    // MARK: - Environment
+
+    struct _Environment
+    {
+        let cardStore: CardStore
+        let favoriteStore: FavoriteStore
+        let sleep: (_ nanoseconds: UInt64) async throws -> Void
+    }
+
+    typealias Environment = SendRouteEnvironment<_Environment, Route>
+
+    // MARK: - Reducer
+
+    static func reducer() -> Reducer<Action, State, Environment>
+    {
+        .debug(name: "[Detail]") { action, state, env in
+            switch action {
+            case .loadFavorite:
+                state.isLoadingFavorite = true
+
+                let cardID = state.card.id
+
+                return Effect {
+                    if let isFavorite = await env.environment.favoriteStore.loadFavorite(id: cardID) {
+                        return ._didLoadFavorite(isFavorite)
+                    }
+                    else {
+                        return ._showError(Error.failedLoadingFavorites)
+                    }
+                }
+
+            case let ._didLoadFavorite(isFavorite):
+                state.card.isFavorite = isFavorite
+                state.isLoadingFavorite = false
+                return .empty
+
+            case .fetchCard:
+                state.isFetchingCard = true
+
+                let cardID = state.card.id
+
+                return Effect {
+                    if let card = try? await env.environment.cardStore.fetchCard(id: cardID) {
+                        return ._didFetchCard(card)
+                    }
+                    else {
+                        return ._showError(Error.failedFetchingCards)
+                    }
+                }
+
+            case let ._didFetchCard(card):
+                state.card.card = card
+                state.isFetchingCard = false
+                return .empty
+
+            case let .didTapHeart(cardID):
+                state.card.isFavorite.toggle()
+
+                return Effect { [state] in
+                    await env.environment.favoriteStore.saveFavorite(id: cardID, isFavorite: state.card.isFavorite)
+                    return nil
+                }
+
+            case let ._showError(error):
+                state.errorString = error.localizedDescription
+
+                switch error {
+                case .failedLoadingFavorites:
+                    state.isLoadingFavorite = false
+
+                case .failedFetchingCards:
+                    state.isFetchingCard = false
+                }
+
+                return Effect {
+                    try await env.environment.sleep(2_000_000_000)
+                    return ._hideError
+                }
+
+            case ._hideError:
+                state.errorString = nil
+                return .empty
+            }
+        }
+    }
+
+    // MARK: - Error
+
+    enum Error: Swift.Error
+    {
+        case failedLoadingFavorites
+        case failedFetchingCards
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailBuilder.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailBuilder.swift
@@ -1,0 +1,21 @@
+import UIKit
+import ActomatonStore
+
+@MainActor
+public enum DetailBuilder
+{
+    static func build(card: CardWithFavorite, environment: Detail._Environment) -> UIViewController
+    {
+        let store = RouteStore(
+            state: Detail.State(card: card),
+            reducer: Detail.reducer(),
+            environment: environment,
+            routeType: Detail.Route.self
+        )
+
+        let vc = HostingViewController(store: store, makeView: DetailView.init)
+        vc.title = "Detail"
+
+        return vc
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailView.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import ActomatonStore
+
+@MainActor
+struct DetailView: View
+{
+    private let store: Store<Action, State>.Proxy
+
+    init(store: Store<Action, State>.Proxy)
+    {
+        self.store = store
+    }
+
+    var body: some View
+    {
+        VStack {
+            cardView(card: store.state.card)
+            cardViewFooter(card: store.state.card)
+        }
+        .onAppear {
+            store.send(.loadFavorite)
+            store.send(.fetchCard)
+        }
+    }
+
+    @ViewBuilder
+    private func cardView(card: CardWithFavorite) -> some View
+    {
+        ZStack(alignment: .topTrailing) {
+            Image(systemName: card.symbol)
+                .font(.system(size: 30))
+                .frame(width: 150, height: 150)
+                .background(card.color)
+                .cornerRadius(10)
+
+            Button {
+                store.send(.didTapHeart(card.id))
+            } label: {
+                Image(systemName: card.isFavorite ? "heart.fill" : "heart")
+                    .font(.system(size: 30))
+                    .frame(width: 30, height: 30)
+
+            }
+            .offset(x: -10, y: 10)
+        }
+    }
+
+    @ViewBuilder
+    private func cardViewFooter(card: CardWithFavorite) -> some View
+    {
+        Text("ID: \(card.id)")
+        Text(card.title)
+        Text(card.description)
+    }
+
+    typealias Action = Detail.Action
+    typealias State = Detail.State
+    typealias Route = Detail.Route
+}
+
+struct DetailView_Previews: PreviewProvider
+{
+    static var previews: some View
+    {
+        DetailView(
+            store: .init(
+                state: .constant(
+                    Detail.State(
+                        card: .init(
+                            card: Card.fakedFetchedCards[0],
+                            color: .yellow,
+                            isFavorite: false
+                        )
+                    )
+                ),
+                send: { _ in }
+            )
+        )
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Favorite/FavoriteBuilder.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Favorite/FavoriteBuilder.swift
@@ -1,0 +1,44 @@
+import UIKit
+import ActomatonStore
+
+@MainActor
+public enum FavoriteBuilder
+{
+    static func buildNavigation(environment: CardList._Environment) -> UIViewController
+    {
+        let store = RouteStore(
+            state: CardList.State(showsFavoriteOnly: true),
+            reducer: CardList.reducer(),
+            environment: environment,
+            routeType: CardList.Route.self
+        )
+
+        let vc = HostingViewController(store: store, makeView: CardListView.init)
+        vc.title = "Favorite"
+        vc.tabBarItem = UITabBarItem(
+            title: "Favorite",
+            image: UIImage(systemName: "star")!,
+            selectedImage: UIImage(systemName: "star.fill")!
+        )
+
+        let navC = UINavigationController(rootViewController: vc)
+
+        store.subscribeRoutes { [weak navC] route in
+            print("===> route", route)
+            switch route {
+            case let .showDetail(card):
+                let vc = DetailBuilder.build(
+                    card: card,
+                    environment: .init(
+                        cardStore: environment.cardStore,
+                        favoriteStore: environment.favoriteStore,
+                        sleep: environment.sleep
+                    )
+                )
+                navC?.pushViewController(vc, animated: true)
+            }
+        }
+
+        return navC
+    }
+}

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Home/HomeBuilder.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Home/HomeBuilder.swift
@@ -1,0 +1,44 @@
+import UIKit
+import ActomatonStore
+
+@MainActor
+public enum HomeBuilder
+{
+    static func buildNavigation(environment: CardList._Environment) -> UIViewController
+    {
+        let store = RouteStore(
+            state: CardList.State(showsFavoriteOnly: false),
+            reducer: CardList.reducer(),
+            environment: environment,
+            routeType: CardList.Route.self
+        )
+
+        let vc = HostingViewController(store: store, makeView: CardListView.init)
+        vc.title = "Home"
+        vc.tabBarItem = UITabBarItem(
+            title: "Home",
+            image: UIImage(systemName: "house")!,
+            selectedImage: UIImage(systemName: "house.fill")!
+        )
+
+        let navC = UINavigationController(rootViewController: vc)
+
+        store.subscribeRoutes { [weak navC] route in
+            print("===> route", route)
+            switch route {
+            case let .showDetail(card):
+                let vc = DetailBuilder.build(
+                    card: card,
+                    environment: .init(
+                        cardStore: environment.cardStore,
+                        favoriteStore: environment.favoriteStore,
+                        sleep: environment.sleep
+                    )
+                )
+                navC?.pushViewController(vc, animated: true)
+            }
+        }
+
+        return navC
+    }
+}


### PR DESCRIPTION
This PR adds `Actomaton-Favorite-Sync` example that uses `RouteStore` with UIKit-navigation-based architecture
to demonstrate Favorite Sync in multiple screens.

## Screencast

https://user-images.githubusercontent.com/138476/148794334-c9a512c1-d361-467a-b3e4-8a98a8a2aba0.mp4


