### PR TITLE
Refactor by adding `Store`'s' `Environment` type parameter

### DIFF
--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,50 +1,52 @@
 {
-  "pins" : [
-    {
-      "identity" : "actomaton",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inamiy/Actomaton",
-      "state" : {
-        "branch" : "main",
-        "revision" : "6aa9733246722f5ebe257848b7fb09ccfd4d5c17"
+  "object": {
+    "pins": [
+      {
+        "package": "Actomaton",
+        "repositoryURL": "https://github.com/inamiy/Actomaton",
+        "state": {
+          "branch": "main",
+          "revision": "2cef51434218713343f3b8e3d2d3a70b3832b272",
+          "version": null
+        }
+      },
+      {
+        "package": "CombineCocoa",
+        "repositoryURL": "https://github.com/CombineCommunity/CombineCocoa",
+        "state": {
+          "branch": null,
+          "revision": "4e262c2f9fb1cee1cb3be5717f7e6b55eb823971",
+          "version": "0.4.0"
+        }
+      },
+      {
+        "package": "swift-case-paths",
+        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
+        "state": {
+          "branch": null,
+          "revision": "241301b67d8551c26d8f09bd2c0e52cc49f18007",
+          "version": "0.8.0"
+        }
+      },
+      {
+        "package": "swift-custom-dump",
+        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
+        "state": {
+          "branch": null,
+          "revision": "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
+          "version": "0.2.1"
+        }
       }
-    },
-    {
-      "identity" : "combinecocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CombineCommunity/CombineCocoa",
-      "state" : {
-        "revision" : "4e262c2f9fb1cee1cb3be5717f7e6b55eb823971",
-        "version" : "0.4.0"
-      }
-    },
-    {
-      "identity" : "swift-case-paths",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
-      "state" : {
-        "revision" : "241301b67d8551c26d8f09bd2c0e52cc49f18007",
-        "version" : "0.8.0"
-      }
-    },
-    {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
-        "version" : "0.3.0"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "50a70a9d3583fe228ce672e8923010c8df2deddd",
-        "version" : "0.2.1"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/CardList/CardListView.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/CardList/CardListView.swift
@@ -4,9 +4,9 @@ import ActomatonStore
 @MainActor
 struct CardListView: View
 {
-    private let store: Store<Action, State>.Proxy
+    private let store: Store<Action, State, Void>.Proxy
 
-    init(store: Store<Action, State>.Proxy)
+    init(store: Store<Action, State, Void>.Proxy)
     {
         self.store = store
     }
@@ -122,6 +122,7 @@ struct CardListView_Previews: PreviewProvider
         CardListView(
             store: .init(
                 state: .constant(CardList.State(cards: Card.fakedFetchedCards, showsFavoriteOnly: false)),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/CardList/CardListViewController.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/CardList/CardListViewController.swift
@@ -5,7 +5,7 @@ import ActomatonStore
 
 final class CardListViewController: UIViewController
 {
-    private let store: Store<Action, State>
+    private let store: Store<Action, State, Environment>
 
     private var dataSource: UICollectionViewDiffableDataSource<Section, Item>?
 
@@ -39,7 +39,7 @@ final class CardListViewController: UIViewController
         return emptyLabel
     }()
 
-    init(store: Store<Action, State>)
+    init(store: Store<Action, State, Environment>)
     {
         self.store = store
         super.init(nibName: nil, bundle: nil)
@@ -113,6 +113,7 @@ final class CardListViewController: UIViewController
 
     typealias Action = CardList.Action
     typealias State = CardList.State
+    typealias Environment = CardList.Environment
     typealias Route = CardList.Route
 }
 
@@ -177,7 +178,7 @@ private struct Item: Hashable
 
 private func makeDataSource(
     collectionView: UICollectionView,
-    store: Store<CardList.Action, CardList.State>
+    store: Store<CardList.Action, CardList.State, CardList.Environment>
 ) -> UICollectionViewDiffableDataSource<Section, Item>
 {
     let cellRegistration = UICollectionView.CellRegistration<CardListCell, Item>() { cell, indexPath, item in

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailBuilder.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailBuilder.swift
@@ -19,7 +19,7 @@ public enum DetailBuilder
 
         let vc = usesUIKit
             ? DetailViewController(store: store)
-            : HostingViewController(store: store, makeView: DetailView.init)
+            : HostingViewController.make(store: store, makeView: DetailView.init)
         vc.title = "Detail"
 
         return vc

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailView.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailView.swift
@@ -4,9 +4,9 @@ import ActomatonStore
 @MainActor
 struct DetailView: View
 {
-    private let store: Store<Action, State>.Proxy
+    private let store: Store<Action, State, Void>.Proxy
 
-    init(store: Store<Action, State>.Proxy)
+    init(store: Store<Action, State, Void>.Proxy)
     {
         self.store = store
     }
@@ -73,6 +73,7 @@ struct DetailView_Previews: PreviewProvider
                         )
                     )
                 ),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailViewController.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Detail/DetailViewController.swift
@@ -5,11 +5,11 @@ import ActomatonStore
 
 final class DetailViewController: UIViewController
 {
-    private let store: Store<Action, State>
+    private let store: Store<Action, State, Environment>
 
     private var cancellables: Set<AnyCancellable> = []
 
-    init(store: Store<Action, State>)
+    init(store: Store<Action, State, Environment>)
     {
         self.store = store
         super.init(nibName: nil, bundle: nil)
@@ -103,5 +103,6 @@ final class DetailViewController: UIViewController
 
     typealias Action = Detail.Action
     typealias State = Detail.State
+    typealias Environment = Detail.Environment
     typealias Route = Detail.Route
 }

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Favorite/FavoriteBuilder.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Favorite/FavoriteBuilder.swift
@@ -18,7 +18,7 @@ public enum FavoriteBuilder
 
         let vc = usesUIKit
             ? CardListViewController(store: store)
-            : HostingViewController(store: store, makeView: CardListView.init)
+            : HostingViewController.make(store: store, makeView: CardListView.init)
         vc.title = "Favorite"
         vc.tabBarItem = UITabBarItem(
             title: "Favorite",

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Home/HomeBuilder.swift
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync/Scenes/Home/HomeBuilder.swift
@@ -18,7 +18,7 @@ public enum HomeBuilder
 
         let vc = usesUIKit
             ? CardListViewController(store: store)
-            : HostingViewController(store: store, makeView: CardListView.init)
+            : HostingViewController.make(store: store, makeView: CardListView.init)
         vc.title = "Home"
         vc.tabBarItem = UITabBarItem(
             title: "Home",

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/inamiy/Actomaton",
         "state": {
           "branch": "main",
-          "revision": "6aa9733246722f5ebe257848b7fb09ccfd4d5c17",
+          "revision": "2cef51434218713343f3b8e3d2d3a70b3832b272",
           "version": null
         }
       },

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/AppView.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/AppView.swift
@@ -12,11 +12,11 @@ import DebugRoot
 struct AppView: View
 {
     @StateObject
-    private var store: Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>>
+    private var store: Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>, HomeEnvironment>
 
     init()
     {
-        let store = Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>>(
+        let store = Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>, HomeEnvironment>(
             state: DebugRoot.State(inner: Root.State.initialState),
             reducer: DebugRoot.reducer(inner: Root.reducer()),
             environment: HomeEnvironment.live

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/TestAppView.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/TestAppView.swift
@@ -6,11 +6,11 @@ import GameOfLife
 struct TestAppView: View
 {
     @StateObject
-    private var store: Store<GameOfLife.Root.Action, GameOfLife.Root.State>
+    private var store: Store<GameOfLife.Root.Action, GameOfLife.Root.State, GameOfLife.Root.Environment>
 
     init()
     {
-        let store = Store<GameOfLife.Root.Action, GameOfLife.Root.State>(
+        let store = Store<GameOfLife.Root.Action, GameOfLife.Root.State, GameOfLife.Root.Environment>(
             state: GameOfLife.Root.State(pattern: .glider, cellLength: 5),
             reducer: GameOfLife.Root.reducer(),
             environment: .live
@@ -21,6 +21,6 @@ struct TestAppView: View
     var body: some View
     {
         // IMPORTANT: Pass `Store.Proxy` to children.
-        GameOfLife.RootView(store: self.store.proxy)
+        GameOfLife.RootView(store: self.store.proxy.map(environment: { _ in () }))
     }
 }

--- a/Examples/UIKit-Gallery/Actomaton-UIKit-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/UIKit-Gallery/Actomaton-UIKit-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/inamiy/Actomaton",
         "state": {
           "branch": "main",
-          "revision": "6aa9733246722f5ebe257848b7fb09ccfd4d5c17",
+          "revision": "2cef51434218713343f3b8e3d2d3a70b3832b272",
           "version": null
         }
       },

--- a/Sources/CanvasPlayer/CanvasPlayerView.swift
+++ b/Sources/CanvasPlayer/CanvasPlayerView.swift
@@ -7,15 +7,15 @@ import CommonUI
 public struct CanvasPlayerView<CanvasState>: View
     where CanvasState: Equatable & Sendable
 {
-    let store: Store<Action, State<CanvasState>>.Proxy
-    let content: @MainActor (Store<Action, State<CanvasState>>.Proxy) -> AnyView
-    let bottomView: @MainActor (Store<Action, State<CanvasState>>.Proxy) -> AnyView
+    let store: Store<Action, State<CanvasState>, Void>.Proxy
+    let content: @MainActor (Store<Action, State<CanvasState>, Void>.Proxy) -> AnyView
+    let bottomView: @MainActor (Store<Action, State<CanvasState>, Void>.Proxy) -> AnyView
 
     /// Initializer with custom `content`.
     public init(
-        store: Store<Action, State<CanvasState>>.Proxy,
-        content: @MainActor @escaping (Store<Action, State<CanvasState>>.Proxy) -> AnyView,
-        bottomView: @MainActor @escaping (Store<Action, State<CanvasState>>.Proxy) -> AnyView = { _ in AnyView(EmptyView()) }
+        store: Store<Action, State<CanvasState>, Void>.Proxy,
+        content: @MainActor @escaping (Store<Action, State<CanvasState>, Void>.Proxy) -> AnyView,
+        bottomView: @MainActor @escaping (Store<Action, State<CanvasState>, Void>.Proxy) -> AnyView = { _ in AnyView(EmptyView()) }
     )
     {
         self.store = store

--- a/Sources/CanvasPlayer/CanvasView.swift
+++ b/Sources/CanvasPlayer/CanvasView.swift
@@ -7,13 +7,13 @@ import CommonUI
 public struct CanvasView<CanvasState>: View
     where CanvasState: Equatable & Sendable
 {
-    let store: Store<Action, State<CanvasState>>.Proxy
-    let content: @MainActor (Store<Action, State<CanvasState>>.Proxy) -> AnyView
+    let store: Store<Action, State<CanvasState>, Void>.Proxy
+    let content: @MainActor (Store<Action, State<CanvasState>, Void>.Proxy) -> AnyView
 
     /// Initializer with custom `content`.
     public init(
-        store: Store<Action, State<CanvasState>>.Proxy,
-        content: @MainActor @escaping (Store<Action, State<CanvasState>>.Proxy) -> AnyView
+        store: Store<Action, State<CanvasState>, Void>.Proxy,
+        content: @MainActor @escaping (Store<Action, State<CanvasState>, Void>.Proxy) -> AnyView
     )
     {
         self.store = store

--- a/Sources/ColorFilter/ColorFilterView.swift
+++ b/Sources/ColorFilter/ColorFilterView.swift
@@ -13,9 +13,9 @@ public struct ColorFilterView: View
     @SwiftUI.State
     private var isShowingPicker = false
 
-    private let store: Store<ColorFilter.Action, ColorFilter.State>.Proxy
+    private let store: Store<ColorFilter.Action, ColorFilter.State, Void>.Proxy
 
-    public init(store: Store<ColorFilter.Action, ColorFilter.State>.Proxy)
+    public init(store: Store<ColorFilter.Action, ColorFilter.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -104,6 +104,7 @@ struct ColorFilterView_Previews: PreviewProvider
         ColorFilterView(
             store: .init(
                 state: .constant(.init()),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/Counter/CounterView.swift
+++ b/Sources/Counter/CounterView.swift
@@ -4,9 +4,9 @@ import ActomatonStore
 @MainActor
 public struct CounterView: View
 {
-    private let store: Store<Counter.Action, Counter.State>.Proxy
+    private let store: Store<Counter.Action, Counter.State, Void>.Proxy
 
-    public init(store: Store<Counter.Action, Counter.State>.Proxy)
+    public init(store: Store<Counter.Action, Counter.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -38,6 +38,7 @@ struct CounterView_Previews: PreviewProvider
         CounterView(
             store: .init(
                 state: .constant(.init()),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/DebugRoot/DebugRootView.swift
+++ b/Sources/DebugRoot/DebugRootView.swift
@@ -6,9 +6,9 @@ import ActomatonStore
 public struct DebugRootView<RootView>: View
     where RootView: View & RootViewProtocol
 {
-    private let store: Store<DebugAction, DebugState>.Proxy
+    private let store: Store<DebugAction, DebugState, RootView.Environment>.Proxy
 
-    public init(store: Store<DebugAction, DebugState>.Proxy)
+    public init(store: Store<DebugAction, DebugState, RootView.Environment>.Proxy)
     {
         self.store = store
     }
@@ -21,8 +21,6 @@ public struct DebugRootView<RootView>: View
                     .contramap(action: { DebugAction.timeTravel(.inner($0)) })
             )
                 .frame(maxHeight: .infinity)
-
-
 
             if self.store.state.usesTimeTravel {
                 self.timeTravelDebugView()
@@ -99,7 +97,7 @@ struct DebugRootView_Previews: PreviewProvider
 
         struct RootView: View, RootViewProtocol
         {
-            init(store: Store<RootAction, RootState>.Proxy) {}
+            init(store: Store<RootAction, RootState, Void>.Proxy) {}
 
             var body: some View
             {
@@ -111,6 +109,7 @@ struct DebugRootView_Previews: PreviewProvider
             DebugRootView<RootView>(
                 store: .init(
                     state: .constant(.init(inner: RootState())),
+                    environment: (),
                     send: { _ in }
                 )
             )

--- a/Sources/DebugRoot/RootProtocol.swift
+++ b/Sources/DebugRoot/RootProtocol.swift
@@ -21,6 +21,7 @@ public protocol RootViewProtocol
 {
     associatedtype Action: Sendable
     associatedtype State: RootStateProtocol & Equatable & Sendable
+    associatedtype Environment: Sendable
 
-    init(store: Store<Action, State>.Proxy)
+    init(store: Store<Action, State, Environment>.Proxy)
 }

--- a/Sources/GameOfLife/Screens/Game/GameView.swift
+++ b/Sources/GameOfLife/Screens/Game/GameView.swift
@@ -5,10 +5,10 @@ import CommonUI
 @MainActor
 struct GameView: View
 {
-    private let store: Store<Game.Action, Game.State>.Proxy
+    private let store: Store<Game.Action, Game.State, Void>.Proxy
 
     init(
-        store: Store<Game.Action, Game.State>.Proxy
+        store: Store<Game.Action, Game.State, Void>.Proxy
     )
     {
         self.store = store
@@ -60,6 +60,7 @@ struct GameView_Previews: PreviewProvider
         let gameView = GameView(
             store: .init(
                 state: .constant(.init(pattern: .glider, cellLength: 5, timerInterval: 1)),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/GameOfLife/Screens/PatternSelect/PatternSelectView.swift
+++ b/Sources/GameOfLife/Screens/PatternSelect/PatternSelectView.swift
@@ -5,9 +5,9 @@ import CommonUI
 @MainActor
 struct PatternSelectView: View
 {
-    private let store: Store<PatternSelect.Action, PatternSelect.State>.Proxy
+    private let store: Store<PatternSelect.Action, PatternSelect.State, Void>.Proxy
 
-    init(store: Store<PatternSelect.Action, PatternSelect.State>.Proxy)
+    init(store: Store<PatternSelect.Action, PatternSelect.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -112,6 +112,7 @@ struct PatternSelectView_Previews: PreviewProvider
         let gameOfLifeView = PatternSelectView(
             store: .init(
                 state: .constant(.init()),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/GameOfLife/Screens/Root/GameOfLifeRootView.swift
+++ b/Sources/GameOfLife/Screens/Root/GameOfLifeRootView.swift
@@ -5,9 +5,9 @@ import CanvasPlayer
 @MainActor
 public struct RootView: View
 {
-    private let store: Store<Root.Action, Root.State>.Proxy
+    private let store: Store<Root.Action, Root.State, Void>.Proxy
 
-    public init(store: Store<Root.Action, Root.State>.Proxy)
+    public init(store: Store<Root.Action, Root.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -101,6 +101,7 @@ struct RootView_Previews: PreviewProvider
         let gameOfLifeView = RootView(
             store: .init(
                 state: .constant(.init(pattern: .glider, cellLength: 5, timerInterval: 1)),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/GitHub/GitHubView.swift
+++ b/Sources/GitHub/GitHubView.swift
@@ -5,9 +5,9 @@ import CommonUI
 @MainActor
 public struct GitHubView: View
 {
-    private let store: Store<GitHub.Action, GitHub.State>.Proxy
+    private let store: Store<GitHub.Action, GitHub.State, Void>.Proxy
 
-    public init(store: Store<GitHub.Action, GitHub.State>.Proxy)
+    public init(store: Store<GitHub.Action, GitHub.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -120,6 +120,7 @@ struct GitHubView_Previews: PreviewProvider
         GitHubView(
             store: .init(
                 state: .constant(.init()),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/Home/ExampleList/Examples/ColorFilterExample.swift
+++ b/Sources/Home/ExampleList/Examples/ColorFilterExample.swift
@@ -11,7 +11,7 @@ struct ColorFilterExample: Example
         .colorFilter(ColorFilter.State())
     }
 
-    func exampleView(store: Store<Home.Action, Home.State>.Proxy) -> AnyView
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/ExampleList/Examples/CounterExample.swift
+++ b/Sources/Home/ExampleList/Examples/CounterExample.swift
@@ -11,7 +11,7 @@ struct CounterExample: Example
         .counter(Counter.State())
     }
 
-    func exampleView(store: Store<Home.Action, Home.State>.Proxy) -> AnyView
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/ExampleList/Examples/GameOfLifeExample.swift
+++ b/Sources/Home/ExampleList/Examples/GameOfLifeExample.swift
@@ -11,7 +11,7 @@ struct GameOfLifeExample: Example
         .gameOfLife(GameOfLife.Root.State(pattern: .glider, cellLength: 5))
     }
 
-    func exampleView(store: Store<Action, State>.Proxy) -> AnyView
+    func exampleView(store: Store<Action, State, Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/ExampleList/Examples/GitHubExample.swift
+++ b/Sources/Home/ExampleList/Examples/GitHubExample.swift
@@ -11,7 +11,7 @@ struct GitHubExample: Example
         .github(GitHub.State())
     }
 
-    func exampleView(store: Store<Home.Action, Home.State>.Proxy) -> AnyView
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/ExampleList/Examples/PhysicsExample.swift
+++ b/Sources/Home/ExampleList/Examples/PhysicsExample.swift
@@ -11,7 +11,7 @@ struct PhysicsExample: Example
         .physics(PhysicsRoot.State(current: nil))
     }
 
-    func exampleView(store: Store<Home.Action, Home.State>.Proxy) -> AnyView
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/ExampleList/Examples/StateDiagramExample.swift
+++ b/Sources/Home/ExampleList/Examples/StateDiagramExample.swift
@@ -11,7 +11,7 @@ struct StateDiagramExample: Example
         .stateDiagram(.loggedOut)
     }
 
-    func exampleView(store: Store<Home.Action, Home.State>.Proxy) -> AnyView
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/ExampleList/Examples/StopwatchExample.swift
+++ b/Sources/Home/ExampleList/Examples/StopwatchExample.swift
@@ -11,7 +11,7 @@ struct StopwatchExample: Example
         .stopwatch(Stopwatch.State())
     }
 
-    func exampleView(store: Store<Home.Action, Home.State>.Proxy) -> AnyView
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/ExampleList/Examples/SyncCountersExample.swift
+++ b/Sources/Home/ExampleList/Examples/SyncCountersExample.swift
@@ -11,7 +11,7 @@ struct SyncCountersExample: Example
         .syncCounters(SyncCounters.State())
     }
 
-    func exampleView(store: Store<Home.Action, Home.State>.Proxy) -> AnyView
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/ExampleList/Examples/TodoExample.swift
+++ b/Sources/Home/ExampleList/Examples/TodoExample.swift
@@ -11,7 +11,7 @@ struct TodoExample: Example
         .todo(Todo.State())
     }
 
-    func exampleView(store: Store<Home.Action, Home.State>.Proxy) -> AnyView
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/ExampleList/Examples/VideoDetectorExample.swift
+++ b/Sources/Home/ExampleList/Examples/VideoDetectorExample.swift
@@ -11,7 +11,7 @@ struct VideoDetectorExample: Example
         .videoDetector(VideoDetector.State())
     }
 
-    func exampleView(store: Store<Home.Action, Home.State>.Proxy) -> AnyView
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
     {
         Self.exampleView(
             store: store,

--- a/Sources/Home/HomeView.swift
+++ b/Sources/Home/HomeView.swift
@@ -4,9 +4,9 @@ import ActomatonStore
 @MainActor
 public struct HomeView: View
 {
-    private let store: Store<Action, State>.Proxy
+    private let store: Store<Action, State, Environment>.Proxy
 
-    public init(store: Store<Action, State>.Proxy)
+    public init(store: Store<Action, State, Environment>.Proxy)
     {
         self.store = store
     }
@@ -80,6 +80,7 @@ struct HomeView_Previews: PreviewProvider
             HomeView(
                 store: .init(
                     state: .constant(State(current: nil, usesTimeTravel: true, isDebuggingTab: true)),
+                    environment: .live,
                     send: { _ in }
                 )
             )
@@ -89,6 +90,7 @@ struct HomeView_Previews: PreviewProvider
             HomeView(
                 store: .init(
                     state: .constant(State(current: .counter(.init()), usesTimeTravel: true, isDebuggingTab: true)),
+                    environment: .live,
                     send: { _ in }
                 )
             )

--- a/Sources/Physics/ExampleList/Example.swift
+++ b/Sources/Physics/ExampleList/Example.swift
@@ -17,7 +17,7 @@ protocol Example
     var exampleArrowScale: ArrowScale { get }
 
     @MainActor
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
 }
 
 extension Example
@@ -46,10 +46,10 @@ extension Example
     /// Helper method to transform parent `Store` into child `Store`, then `makeView`.
     @MainActor
     static func exampleView<ChildAction, ChildState, V: View>(
-        store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy,
+        store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy,
         action: @escaping (ChildAction) -> PhysicsRoot.Action,
         statePath: CasePath<PhysicsRoot.State.Current, ChildState>,
-        makeView: @MainActor (Store<ChildAction, ChildState>.Proxy) -> V
+        makeView: @MainActor (Store<ChildAction, ChildState, Void>.Proxy) -> V
     ) -> AnyView
     {
         @MainActor

--- a/Sources/Physics/ExampleList/Examples/CollisionExample.swift
+++ b/Sources/Physics/ExampleList/Examples/CollisionExample.swift
@@ -17,7 +17,7 @@ struct CollisionExample: Example
         .init(velocityArrowScale: 10, forceArrowScale: 0)
     }
 
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
     {
         let configuration = store.state.configuration
 

--- a/Sources/Physics/ExampleList/Examples/DoublePendulumExample.swift
+++ b/Sources/Physics/ExampleList/Examples/DoublePendulumExample.swift
@@ -47,7 +47,7 @@ struct DoublePendulumExample: Example
         }
     }
 
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
     {
         let configuration = store.state.configuration
 

--- a/Sources/Physics/ExampleList/Examples/GaltonBoardExample.swift
+++ b/Sources/Physics/ExampleList/Examples/GaltonBoardExample.swift
@@ -17,7 +17,7 @@ struct GaltonBoardExample: Example
         .init(velocityArrowScale: 10, forceArrowScale: 0)
     }
 
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
     {
         let configuration = store.state.configuration
 

--- a/Sources/Physics/ExampleList/Examples/GravitySurfaceExample.swift
+++ b/Sources/Physics/ExampleList/Examples/GravitySurfaceExample.swift
@@ -20,7 +20,7 @@ struct GravitySurfaceExample: Example
         .init(velocityArrowScale: 10, forceArrowScale: 300)
     }
 
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
     {
         let configuration = store.state.configuration
 

--- a/Sources/Physics/ExampleList/Examples/GravityUniverseExample.swift
+++ b/Sources/Physics/ExampleList/Examples/GravityUniverseExample.swift
@@ -16,7 +16,7 @@ struct GravityUniverseExample: Example
         .init(velocityArrowScale: 15, forceArrowScale: 300)
     }
 
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
     {
         let configuration = store.state.configuration
 

--- a/Sources/Physics/ExampleList/Examples/LineCollisionExample.swift
+++ b/Sources/Physics/ExampleList/Examples/LineCollisionExample.swift
@@ -23,7 +23,7 @@ struct LineCollisionExample: Example
         .init(velocityArrowScale: 10, forceArrowScale: 0)
     }
 
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
     {
         let configuration = store.state.configuration
 

--- a/Sources/Physics/ExampleList/Examples/PendulumExample.swift
+++ b/Sources/Physics/ExampleList/Examples/PendulumExample.swift
@@ -24,7 +24,7 @@ struct PendulumExample: Example
         .init(velocityArrowScale: 5, forceArrowScale: 100)
     }
 
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
     {
         let configuration = store.state.configuration
 

--- a/Sources/Physics/ExampleList/Examples/SpringExample.swift
+++ b/Sources/Physics/ExampleList/Examples/SpringExample.swift
@@ -16,7 +16,7 @@ struct SpringExample: Example
         .init(velocityArrowScale: 10, forceArrowScale: 300)
     }
 
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
     {
         let configuration = store.state.configuration
 

--- a/Sources/Physics/ExampleList/Examples/SpringPendulumExample.swift
+++ b/Sources/Physics/ExampleList/Examples/SpringPendulumExample.swift
@@ -18,7 +18,7 @@ struct SpringPendulumExample: Example
         .init(velocityArrowScale: 10, forceArrowScale: 100)
     }
 
-    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy) -> AnyView
+    func exampleView(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy) -> AnyView
     {
         let configuration = store.state.configuration
 

--- a/Sources/Physics/PhysicsRoot/PhysicsRootView.swift
+++ b/Sources/Physics/PhysicsRoot/PhysicsRootView.swift
@@ -5,9 +5,9 @@ import Utilities
 @MainActor
 public struct PhysicsRootView: View
 {
-    private let store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy
+    private let store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy
 
-    public init(store: Store<PhysicsRoot.Action, PhysicsRoot.State>.Proxy)
+    public init(store: Store<PhysicsRoot.Action, PhysicsRoot.State, Void>.Proxy)
     {
         self.store = store
     }

--- a/Sources/Physics/World/WorldView+Content.swift
+++ b/Sources/Physics/World/WorldView+Content.swift
@@ -8,7 +8,7 @@ extension WorldView
     /// Initializer with default `content`.
     /// - Note: Makes contents, UI controls, etc.
     init(
-        store: Store<World.Action, World.State<Obj>>.Proxy,
+        store: Store<World.Action, World.State<Obj>, Void>.Proxy,
         configuration: WorldConfiguration,
         absolutePosition: ((_ relativePosition: Vector2, _ index: Int, _ previous: Vector2) -> Vector2)?,
         arrowScale: ArrowScale
@@ -32,7 +32,7 @@ extension WorldView
     /// Makes contents i.e. `objects`, `velocityArrows`, `forceArrows`.
     @MainActor
     static func makeContentView(
-        store: Store<World.Action, World.CanvasState<Obj>>.Proxy,
+        store: Store<World.Action, World.CanvasState<Obj>, Void>.Proxy,
         configuration: WorldConfiguration,
         absolutePosition: ((_ relativePosition: Vector2, _ index: Int, _ previous: Vector2) -> Vector2)?,
         arrowScale: ArrowScale

--- a/Sources/Physics/World/WorldView.swift
+++ b/Sources/Physics/World/WorldView.swift
@@ -7,15 +7,15 @@ import CanvasPlayer
 @MainActor
 struct WorldView<Obj>: View where Obj: ObjectLike & Equatable
 {
-    let store: Store<World.Action, World.State<Obj>>.Proxy
+    let store: Store<World.Action, World.State<Obj>, Void>.Proxy
     let configuration: WorldConfiguration
-    let content: @MainActor (Store<CanvasPlayer.Action, CanvasPlayer.State<World.CanvasState<Obj>>>.Proxy, WorldConfiguration) -> AnyView
+    let content: @MainActor (Store<CanvasPlayer.Action, CanvasPlayer.State<World.CanvasState<Obj>>, Void>.Proxy, WorldConfiguration) -> AnyView
 
     /// Initializer with custom `content`.
     init(
-        store: Store<World.Action, World.State<Obj>>.Proxy,
+        store: Store<World.Action, World.State<Obj>, Void>.Proxy,
         configuration: WorldConfiguration,
-        content: @MainActor @escaping (Store<CanvasPlayer.Action, CanvasPlayer.State<World.CanvasState<Obj>>>.Proxy, WorldConfiguration) -> AnyView
+        content: @MainActor @escaping (Store<CanvasPlayer.Action, CanvasPlayer.State<World.CanvasState<Obj>>, Void>.Proxy, WorldConfiguration) -> AnyView
     )
     {
         self.store = store

--- a/Sources/Root/RootView.swift
+++ b/Sources/Root/RootView.swift
@@ -11,9 +11,9 @@ import UserSession
 @MainActor
 public struct RootView: View
 {
-    private let store: Store<Action, State>.Proxy
+    private let store: Store<Action, State, Environment>.Proxy
 
-    public init(store: Store<Action, State>.Proxy)
+    public init(store: Store<Action, State, Environment>.Proxy)
     {
         self.store = store
     }
@@ -93,14 +93,16 @@ public struct RootView: View
                     HomeView(store: childStore_)
                 }
                 else if let childStore_ = childStore
-                            .contramap(action: TabCaseAction.settings)[casePath: /TabCaseState.settings]
-                            .traverse(\.self)
+                    .map(environment: { _ in () })
+                    .contramap(action: TabCaseAction.settings)[casePath: /TabCaseState.settings]
+                    .traverse(\.self)
                 {
                     SettingsView(store: childStore_, usesNavigationView: true)
                 }
                 else if let childStore_ = childStore
-                            .contramap(action: TabCaseAction.counter)[casePath: /TabCaseState.counter]
-                            .traverse(\.self)
+                    .map(environment: { _ in () })
+                    .contramap(action: TabCaseAction.counter)[casePath: /TabCaseState.counter]
+                    .traverse(\.self)
                 {
                     CounterView(store: childStore_)
                 }
@@ -138,7 +140,7 @@ public struct RootView: View
 
     // MARK: - SubStore
 
-    private var userSessionStore: Store<UserSession.Action, UserSession.State>.Proxy
+    private var userSessionStore: Store<UserSession.Action, UserSession.State, Environment>.Proxy
     {
         self.store.userSession.contramap(action: Action.userSession)
     }

--- a/Sources/SettingsScene/SettingsView.swift
+++ b/Sources/SettingsScene/SettingsView.swift
@@ -5,10 +5,10 @@ import UserSession
 @MainActor
 public struct SettingsView: View
 {
-    private let store: Store<Action, State>.Proxy
+    private let store: Store<Action, State, Void>.Proxy
     private let usesNavigationView: Bool
 
-    public init(store: Store<Action, State>.Proxy, usesNavigationView: Bool)
+    public init(store: Store<Action, State, Void>.Proxy, usesNavigationView: Bool)
     {
         self.store = store
         self.usesNavigationView = usesNavigationView
@@ -72,6 +72,7 @@ struct SettingsView_Previews: PreviewProvider
         SettingsView(
             store: .init(
                 state: .constant(.init(user: .anonymous)),
+                environment: (),
                 send: { _ in }
             ),
             usesNavigationView: true

--- a/Sources/StateDiagram/StateDiagramView.swift
+++ b/Sources/StateDiagram/StateDiagramView.swift
@@ -4,9 +4,9 @@ import ActomatonStore
 @MainActor
 public struct StateDiagramView: View
 {
-    private let store: Store<StateDiagram.Action, StateDiagram.State>.Proxy
+    private let store: Store<StateDiagram.Action, StateDiagram.State, Void>.Proxy
 
-    public init(store: Store<StateDiagram.Action, StateDiagram.State>.Proxy)
+    public init(store: Store<StateDiagram.Action, StateDiagram.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -99,6 +99,7 @@ struct StateDiagramView_Previews: PreviewProvider
         let stateDiagramView = StateDiagramView(
             store: .init(
                 state: .constant(.loggedOut),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/Stopwatch/StopwatchView.swift
+++ b/Sources/Stopwatch/StopwatchView.swift
@@ -4,9 +4,9 @@ import ActomatonStore
 @MainActor
 public struct StopwatchView: View
 {
-    private let store: Store<Stopwatch.Action, Stopwatch.State>.Proxy
+    private let store: Store<Stopwatch.Action, Stopwatch.State, Void>.Proxy
 
-    public init(store: Store<Stopwatch.Action, Stopwatch.State>.Proxy)
+    public init(store: Store<Stopwatch.Action, Stopwatch.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -102,6 +102,7 @@ struct StopwatchView_Previews: PreviewProvider
                         .init(id: 2, time: 1.0),
                     ]
                 )),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/SyncCounters/SyncCountersView.swift
+++ b/Sources/SyncCounters/SyncCountersView.swift
@@ -5,9 +5,9 @@ import Counter
 @MainActor
 public struct SyncCountersView: View
 {
-    private let store: Store<SyncCounters.Action, SyncCounters.State>.Proxy
+    private let store: Store<SyncCounters.Action, SyncCounters.State, Void>.Proxy
 
-    public init(store: Store<SyncCounters.Action, SyncCounters.State>.Proxy)
+    public init(store: Store<SyncCounters.Action, SyncCounters.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -54,6 +54,7 @@ struct SyncCountersView_Previews: PreviewProvider
         SyncCountersView(
             store: .init(
                 state: .constant(.init()),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/Tab/TabView.swift
+++ b/Sources/Tab/TabView.swift
@@ -2,15 +2,16 @@ import SwiftUI
 import ActomatonStore
 
 @MainActor
-public struct TabView<InnerAction, InnerState, TabID>: View
-    where InnerAction: Sendable, InnerState: Equatable & Sendable, TabID: Hashable & Sendable
+public struct TabView<InnerAction, InnerState, InnerEnvironment, TabID>: View
+where InnerAction: Sendable, InnerState: Equatable & Sendable,
+      InnerEnvironment: Sendable, TabID: Hashable & Sendable
 {
-    private let store: Store<Action<InnerAction, InnerState, TabID>, State<InnerState, TabID>>.Proxy
-    private let content: (TabID, Store<InnerAction, InnerState>.Proxy) -> AnyView
+    private let store: Store<Action<InnerAction, InnerState, TabID>, State<InnerState, TabID>, InnerEnvironment>.Proxy
+    private let content: (TabID, Store<InnerAction, InnerState, InnerEnvironment>.Proxy) -> AnyView
 
     public init<V: View>(
-        store: Store<Action<InnerAction, InnerState, TabID>, State<InnerState, TabID>>.Proxy,
-        @ViewBuilder content: @escaping (TabID, Store<InnerAction, InnerState>.Proxy) -> V
+        store: Store<Action<InnerAction, InnerState, TabID>, State<InnerState, TabID>, InnerEnvironment>.Proxy,
+        @ViewBuilder content: @escaping (TabID, Store<InnerAction, InnerState, InnerEnvironment>.Proxy) -> V
     )
     {
         self.store = store

--- a/Sources/Todo/TodoView.swift
+++ b/Sources/Todo/TodoView.swift
@@ -4,9 +4,9 @@ import ActomatonStore
 @MainActor
 public struct TodoView: View
 {
-    private let store: Store<Todo.Action, Todo.State>.Proxy
+    private let store: Store<Todo.Action, Todo.State, Void>.Proxy
 
-    public init(store: Store<Todo.Action, Todo.State>.Proxy)
+    public init(store: Store<Todo.Action, Todo.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -127,6 +127,7 @@ struct TodoView_Previews: PreviewProvider
         TodoView(
             store: .init(
                 state: .constant(.init()),
+                environment: (),
                 send: { _ in }
             )
         )

--- a/Sources/UIKit/ExampleListUIKit/ExampleListBuilder.swift
+++ b/Sources/UIKit/ExampleListUIKit/ExampleListBuilder.swift
@@ -13,7 +13,7 @@ public enum ExampleListBuilder
             environment: ()
         )
 
-        let exampleListVC = HostingViewController(
+        let exampleListVC = HostingViewController.make(
             store: exampleListStore,
             makeView: ExampleListView.init
         )

--- a/Sources/UIKit/ExampleListUIKit/ExampleListView.swift
+++ b/Sources/UIKit/ExampleListUIKit/ExampleListView.swift
@@ -4,9 +4,9 @@ import ActomatonStore
 @MainActor
 struct ExampleListView: View
 {
-    private let store: Store<ExampleList.Action, ExampleList.State>.Proxy
+    private let store: Store<ExampleList.Action, ExampleList.State, Void>.Proxy
 
-    init(store: Store<ExampleList.Action, ExampleList.State>.Proxy)
+    init(store: Store<ExampleList.Action, ExampleList.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -47,6 +47,7 @@ struct ExampleListView_Previews: PreviewProvider
             ExampleListView(
                 store: .init(
                     state: .constant(ExampleList.State(examples: [])),
+                    environment: (),
                     send: { _ in }
                 )
             )
@@ -56,6 +57,7 @@ struct ExampleListView_Previews: PreviewProvider
             ExampleListView(
                 store: .init(
                     state: .constant(ExampleList.State(examples: [])),
+                    environment: (),
                     send: { _ in }
                 )
             )

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/CounterRouteUIKitExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/CounterRouteUIKitExample.swift
@@ -80,11 +80,11 @@ private typealias Environment = SendRouteEnvironment<Counter.Environment, Route>
 @MainActor
 private final class CounterRouteViewController: UIViewController
 {
-    let store: Store<Action, Counter.State>
+    let store: Store<Action, Counter.State, Environment>
 
     var cancellables: [AnyCancellable] = []
 
-    init(store: Store<Action, Counter.State>)
+    init(store: Store<Action, Counter.State, Environment>)
     {
         self.store = store
         super.init(nibName: nil, bundle: nil)

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/CounterUIKitExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/CounterUIKitExample.swift
@@ -29,11 +29,11 @@ public struct CounterUIKitExample: Example
 @MainActor
 private final class CounterViewController: UIViewController
 {
-    let store: Store<Counter.Action, Counter.State>
+    let store: Store<Counter.Action, Counter.State, Counter.Environment>
 
     var cancellables: [AnyCancellable] = []
 
-    init(store: Store<Counter.Action, Counter.State>)
+    init(store: Store<Counter.Action, Counter.State, Counter.Environment>)
     {
         self.store = store
         super.init(nibName: nil, bundle: nil)

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/GameOfLifeExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/GameOfLifeExample.swift
@@ -12,7 +12,7 @@ public struct GameOfLifeExample: Example
     @MainActor
     public func build() -> UIViewController
     {
-        HostingViewController(
+        HostingViewController.make(
             store: Store(
                 state: .init(pattern: .glider, cellLength: 5),
                 reducer: GameOfLife.Root.reducer(),

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/GitHubExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/GitHubExample.swift
@@ -12,7 +12,7 @@ public struct GitHubExample: Example
     @MainActor
     public func build() -> UIViewController
     {
-        HostingViewController(
+        HostingViewController.make(
             store: Store(
                 state: .init(),
                 reducer: GitHub.reducer,

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/PhysicsExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/PhysicsExample.swift
@@ -12,7 +12,7 @@ public struct PhysicsExample: Example
     @MainActor
     public func build() -> UIViewController
     {
-        HostingViewController(
+        HostingViewController.make(
             store: Store(
                 state: .init(current: nil),
                 reducer: PhysicsRoot.reducer,

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/StopwatchExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/StopwatchExample.swift
@@ -12,7 +12,7 @@ public struct StopwatchExample: Example
     @MainActor
     public func build() -> UIViewController
     {
-        HostingViewController(
+        HostingViewController.make(
             store: Store(
                 state: .init(),
                 reducer: Stopwatch.reducer,

--- a/Sources/UIKit/RootUIKit/RootBuilder.swift
+++ b/Sources/UIKit/RootUIKit/RootBuilder.swift
@@ -28,7 +28,7 @@ public enum RootBuilder
             }
         }
 
-        let weakRootStore = WeakBox<Store<Action, State>>()
+        let weakRootStore = WeakBox<Store<Action, State, Environment>>()
 
         let tabItems: [TabItem<TabID>] = [
             TabItem(
@@ -64,7 +64,7 @@ public enum RootBuilder
 
                     let user = rootStore.state.tab.settings.user
 
-                    let settingsStore = RouteStore<SettingsScene.Action, SettingsScene.State, SettingsScene.Action>(
+                    let settingsStore = RouteStore<SettingsScene.Action, SettingsScene.State, SettingsScene.Environment, SettingsScene.Action>(
                         state: .init(user: user),
                         reducer: SettingsUIKit.reducer,
                         environment: ()
@@ -93,7 +93,7 @@ public enum RootBuilder
                         }
                     }
 
-                    return HostingViewController(
+                    return HostingViewController.make(
                         store: settingsStore,
                         makeView: { store in
                             SettingsView(
@@ -116,7 +116,7 @@ public enum RootBuilder
             isOnboardingComplete: true
         )
 
-        let rootStore = Store<Action, State>(
+        let rootStore = Store<Action, State, Environment>(
             state: state,
             reducer: reducer(),
             environment: environment

--- a/Sources/UIKit/RootUIKit/RootViewController.swift
+++ b/Sources/UIKit/RootUIKit/RootViewController.swift
@@ -11,7 +11,7 @@ import SettingsUIKit
 @MainActor
 public final class RootViewController: UIViewController
 {
-    private let store: Store<Action, State>
+    private let store: Store<Action, State, Environment>
     private var cancellables: [AnyCancellable] = []
 
     private var currentViewController: UIViewController?
@@ -37,7 +37,7 @@ public final class RootViewController: UIViewController
         }
     }
 
-    public init(store: Store<Action, State>)
+    public init(store: Store<Action, State, Environment>)
     {
         self.store = store
 
@@ -129,6 +129,7 @@ public final class RootViewController: UIViewController
             let substore = store.observableProxy
                 .contramap(action: Action.tab)
                 .map { $0.tab }
+                .map(environment: { _ in () })
 
             let vc = TabBuilder.build(store: substore)
             self.currentViewController = vc

--- a/Sources/UIKit/TabUIKit/TabBarController.swift
+++ b/Sources/UIKit/TabUIKit/TabBarController.swift
@@ -9,10 +9,10 @@ import SettingsUIKit
 public final class TabBarController<TabID>: UITabBarController
     where TabID: Equatable & Sendable
 {
-    private let store: Store<Action<TabID>, State<TabID>>.ObservableProxy
+    private let store: Store<Action<TabID>, State<TabID>, Environment>.ObservableProxy
     private var cancellables: [AnyCancellable] = []
 
-    public init(store: Store<Action<TabID>, State<TabID>>.ObservableProxy)
+    public init(store: Store<Action<TabID>, State<TabID>, Environment>.ObservableProxy)
     {
         self.store = store
 

--- a/Sources/UIKit/TabUIKit/TabBuilder.swift
+++ b/Sources/UIKit/TabUIKit/TabBuilder.swift
@@ -6,7 +6,7 @@ public enum TabBuilder
 {
     @MainActor
     public static func build<TabID>(
-        store: Store<Action<TabID>, State<TabID>>.ObservableProxy
+        store: Store<Action<TabID>, State<TabID>, Environment>.ObservableProxy
     ) -> UIViewController
         where TabID: Equatable
     {

--- a/Sources/UIKit/TabUIKit/TabItem.swift
+++ b/Sources/UIKit/TabUIKit/TabItem.swift
@@ -67,8 +67,8 @@ extension TabItem
         id: ID,
         title: String,
         image: UIImage,
-        store: Store<Action, State>,
-        view: @escaping (Store<Action, State>.Proxy) -> V
+        store: Store<Action, State, Environment>,
+        view: @escaping (Store<Action, State, Void>.Proxy) -> V
     )
     {
         self.id = id
@@ -84,8 +84,8 @@ extension TabItem
         id: ID,
         title: String,
         image: UIImage,
-        store: Store<Action, State>.ObservableProxy,
-        view: @escaping (Store<Action, State>.Proxy) -> V
+        store: Store<Action, State, Environment>.ObservableProxy,
+        view: @escaping (Store<Action, State, Void>.Proxy) -> V
     )
     {
         self.id = id

--- a/Sources/VideoDetector/VideoDetectorView.swift
+++ b/Sources/VideoDetector/VideoDetectorView.swift
@@ -5,9 +5,9 @@ import VideoCapture
 @MainActor
 public struct VideoDetectorView: View
 {
-    private let store: Store<VideoDetector.Action, VideoDetector.State>.Proxy
+    private let store: Store<VideoDetector.Action, VideoDetector.State, Void>.Proxy
 
-    public init(store: Store<VideoDetector.Action, VideoDetector.State>.Proxy)
+    public init(store: Store<VideoDetector.Action, VideoDetector.State, Void>.Proxy)
     {
         self.store = store
     }
@@ -162,6 +162,7 @@ struct VideoDetectorView_Previews: PreviewProvider
                             videoCapture: .init(sessionState: sessionState)
                         )
                     ),
+                    environment: (),
                     send: { _ in }
                 )
             )


### PR DESCRIPTION
Implementation of:
- https://github.com/inamiy/Actomaton/pull/36

This PR integrates breaking changes in https://github.com/inamiy/Actomaton/pull/36 , which mainly changes Store's type-signature from `Store<Action, State>` to `Store<Action, State, Environment>`.