### PR TITLE
Add VideoPlayer & VideoPlayerMulti examples

### DIFF
--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		331E1FE026ED20A000719530 /* TestAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppView.swift; sourceTree = "<group>"; };
 		332642E226E4056F00438A10 /* DemoApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoApp.swift; sourceTree = "<group>"; };
 		3326433C26E4094200438A10 /* AppView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
+		339BF50727E4B62B009A90ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "Actomaton-Gallery/Info.plist"; sourceTree = "<group>"; };
 		339F821726FA399B006809CE /* Actomaton-Gallery */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "Actomaton-Gallery"; path = ../..; sourceTree = "<group>"; };
 		33E8F81726E3B374009CC65D /* Actomaton-Gallery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Actomaton-Gallery.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33E8F81E26E3B375009CC65D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -41,6 +42,7 @@
 		33E8F80E26E3B374009CC65D = {
 			isa = PBXGroup;
 			children = (
+				339BF50727E4B62B009A90ED /* Info.plist */,
 				339F821726FA399B006809CE /* Actomaton-Gallery */,
 				33E8F81926E3B374009CC65D /* Actomaton-Gallery */,
 				33E8F81826E3B374009CC65D /* Products */,
@@ -299,6 +301,7 @@
 				DEVELOPMENT_TEAM = UMBZ5WL247;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Actomaton-Gallery/Info.plist";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Uses Camera";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -336,6 +339,7 @@
 				DEVELOPMENT_TEAM = UMBZ5WL247;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Actomaton-Gallery/Info.plist";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Uses Camera";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "AVFoundation-Combine",
+        "repositoryURL": "https://github.com/inamiy/AVFoundation-Combine",
+        "state": {
+          "branch": "main",
+          "revision": "9168c37ae9ff0a43bbfc2806eb15006edc3b2552",
+          "version": null
+        }
+      },
+      {
         "package": "OrientationKit",
         "repositoryURL": "https://github.com/inamiy/OrientationKit",
         "state": {

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/Info.plist
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "AVFoundation-Combine",
+        "repositoryURL": "https://github.com/inamiy/AVFoundation-Combine",
+        "state": {
+          "branch": "main",
+          "revision": "9168c37ae9ff0a43bbfc2806eb15006edc3b2552",
+          "version": null
+        }
+      },
+      {
         "package": "OrientationKit",
         "repositoryURL": "https://github.com/inamiy/OrientationKit",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(url: "https://github.com/inamiy/Actomaton", .branch("main")),
         .package(url: "https://github.com/inamiy/OrientationKit", from: "0.1.0"),
         .package(url: "https://github.com/inamiy/SwiftUI-PhotoPicker", .branch("main")),
+        .package(url: "https://github.com/inamiy/AVFoundation-Combine", .branch("main")),
         .package(url: "https://github.com/nicklockwood/VectorMath", from: "0.4.1")
     ],
     targets: [
@@ -85,6 +86,18 @@ let package = Package(
             ],
             resources: [.copy("GameOfLife-Patterns/")]),
         .target(
+            name: "VideoPlayer",
+            dependencies: [
+                .product(name: "ActomatonStore", package: "Actomaton"),
+                "AVFoundation-Combine"
+            ]),
+        .target(
+            name: "VideoPlayerMulti",
+            dependencies: [
+                .product(name: "ActomatonStore", package: "Actomaton"),
+                "VideoPlayer"
+            ]),
+        .target(
             name: "VideoCapture",
             dependencies: [
                 .product(name: "ActomatonStore", package: "Actomaton"),
@@ -126,7 +139,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ActomatonStore", package: "Actomaton"),
                 "Counter", "SyncCounters", "ColorFilter", "Todo", "StateDiagram", "Stopwatch", "GitHub",
-                "GameOfLife", "VideoDetector", "Physics",
+                "GameOfLife", "VideoPlayerMulti", "VideoDetector", "Physics",
                 "CommonEffects"
             ]),
         .target(

--- a/Sources/Home/ExampleList/ExampleList.swift
+++ b/Sources/Home/ExampleList/ExampleList.swift
@@ -10,6 +10,8 @@ let exampleList: [Example] = [
     StopwatchExample(),
     GitHubExample(),
     GameOfLifeExample(),
+    VideoPlayerExample(),
+    VideoPlayerMultiExample(),
     VideoDetectorExample(),
     PhysicsExample()
 ]

--- a/Sources/Home/ExampleList/Examples/VideoPlayerExample.swift
+++ b/Sources/Home/ExampleList/Examples/VideoPlayerExample.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import ActomatonStore
+import VideoPlayer
+import AVFoundation
+
+struct VideoPlayerExample: Example
+{
+    var exampleIcon: Image { Image(systemName: "film") }
+
+    var exampleInitialState: Home.State.Current
+    {
+        .videoPlayer(VideoPlayer.State(label: ""))
+    }
+
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
+    {
+        Self.exampleView(
+            store: store,
+            action: Home.Action.videoPlayer,
+            statePath: /Home.State.Current.videoPlayer,
+            environment: { $0.videoPlayer },
+            makeView: { store in
+                VideoPlayerView(store: store)
+                    .onAppear {
+                        store.environment.setPlayer(makePlayer())
+                        store.send(.subscribePlayer)
+                        store.send(.start)
+                    }
+                    .onDisappear {
+                        store.send(.stop)
+                    }
+            }
+        )
+    }
+}
+
+// MARK: - Private
+
+private func makePlayer() -> AVPlayer {
+    let urlString = "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+    let player = AVPlayer(url: URL(string: urlString)!)
+    return player
+}

--- a/Sources/Home/ExampleList/Examples/VideoPlayerMultiExample.swift
+++ b/Sources/Home/ExampleList/Examples/VideoPlayerMultiExample.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import ActomatonStore
+import VideoPlayerMulti
+import AVFoundation
+
+struct VideoPlayerMultiExample: Example
+{
+    var exampleIcon: Image { Image(systemName: "film") }
+
+    var exampleInitialState: Home.State.Current
+    {
+        .videoPlayerMulti(VideoPlayerMulti.State(displayMode: .singleSyncedPlayer))
+    }
+
+    func exampleView(store: Store<Home.Action, Home.State, Home.Environment>.Proxy) -> AnyView
+    {
+        Self.exampleView(
+            store: store,
+            action: Home.Action.videoPlayerMulti,
+            statePath: /Home.State.Current.videoPlayerMulti,
+            environment: { $0.videoPlayerMulti },
+            makeView: VideoPlayerMultiView.init
+        )
+    }
+}

--- a/Sources/Home/Home.State.Current.swift
+++ b/Sources/Home/Home.State.Current.swift
@@ -7,6 +7,8 @@ import StateDiagram
 import Stopwatch
 import GitHub
 import GameOfLife
+import VideoPlayer
+import VideoPlayerMulti
 import VideoDetector
 import Physics
 
@@ -23,6 +25,8 @@ extension State
         case todo(Todo.State)
         case github(GitHub.State)
         case gameOfLife(GameOfLife.Root.State)
+        case videoPlayer(VideoPlayer.State)
+        case videoPlayerMulti(VideoPlayerMulti.State)
         case videoDetector(VideoDetector.State)
         case physics(PhysicsRoot.State)
 
@@ -31,13 +35,15 @@ extension State
         {
             switch self {
             case .counter:          return CounterExample()
-            case .syncCounters:    return SyncCountersExample()
+            case .syncCounters:     return SyncCountersExample()
             case .colorFilter:      return ColorFilterExample()
             case .stopwatch:        return StopwatchExample()
             case .stateDiagram:     return StateDiagramExample()
             case .todo:             return TodoExample()
             case .github:           return GitHubExample()
             case .gameOfLife:       return GameOfLifeExample()
+            case .videoPlayer:      return VideoPlayerExample()
+            case .videoPlayerMulti: return VideoPlayerMultiExample()
             case .videoDetector:    return VideoDetectorExample()
             case .physics:          return PhysicsExample()
             }

--- a/Sources/Home/Home.swift
+++ b/Sources/Home/Home.swift
@@ -8,6 +8,8 @@ import StateDiagram
 import Stopwatch
 import GitHub
 import GameOfLife
+import VideoPlayer
+import VideoPlayerMulti
 import VideoDetector
 import Physics
 
@@ -23,6 +25,8 @@ public enum Action: Sendable
     case todo(Todo.Action)
     case github(GitHub.Action)
     case gameOfLife(GameOfLife.Root.Action)
+    case videoPlayer(VideoPlayer.Action)
+    case videoPlayerMulti(VideoPlayerMulti.Action)
     case videoDetector(VideoDetector.Action)
     case physics(PhysicsRoot.Action)
 
@@ -107,6 +111,18 @@ public var reducer: Reducer<Action, State, Environment>
                 .contramap(state: /State.Current.gameOfLife)
                 .contramap(state: \State.current)
                 .contramap(environment: { $0.gameOfLife }),
+
+            VideoPlayer.reducer
+                .contramap(action: /Action.videoPlayer)
+                .contramap(state: /State.Current.videoPlayer)
+                .contramap(state: \State.current)
+                .contramap(environment: \.videoPlayer),
+
+            VideoPlayerMulti.reducer
+                .contramap(action: /Action.videoPlayerMulti)
+                .contramap(state: /State.Current.videoPlayerMulti)
+                .contramap(state: \State.current)
+                .contramap(environment: \.videoPlayerMulti),
 
             VideoDetector.reducer
                 .contramap(action: /Action.videoDetector)

--- a/Sources/Home/HomeEnvironment.swift
+++ b/Sources/Home/HomeEnvironment.swift
@@ -3,6 +3,8 @@ import CommonEffects
 import Stopwatch
 import GitHub
 import GameOfLife
+import VideoPlayer
+import VideoPlayerMulti
 
 public struct HomeEnvironment: Sendable
 {
@@ -11,6 +13,8 @@ public struct HomeEnvironment: Sendable
     let fetchRequest: @Sendable (URLRequest) async throws -> Data
 
     let gameOfLife: GameOfLife.Root.Environment
+    let videoPlayer: VideoPlayer.Environment
+    let videoPlayerMulti: VideoPlayerMulti.Environment
 }
 
 // MARK: - Live Environment
@@ -44,7 +48,9 @@ extension HomeEnvironment
             fetchRequest: { urlRequest in
                 try await CommonEffects.fetchData(for: urlRequest, delegate: nil)
             },
-            gameOfLife: .live
+            gameOfLife: .live,
+            videoPlayer: .live,
+            videoPlayerMulti: .live
         )
     }
 }

--- a/Sources/Root/Root.swift
+++ b/Sources/Root/Root.swift
@@ -79,6 +79,7 @@ extension State
 //                current: .physics(.doublePendulum),
 //                current: .physics(.galtonBoard),
 //                current: .gameOfLife(.init(pattern: .glider, cellLength: 5)),
+//                current: .videoPlayerMulti(.init(mode: .singleSyncedPlayer)),
 
                 current: nil,
                 usesTimeTravel: true,

--- a/Sources/VideoPlayer/VideoPlayer.Environment.live.swift
+++ b/Sources/VideoPlayer/VideoPlayer.Environment.live.swift
@@ -1,0 +1,19 @@
+import AVFoundation
+
+extension Environment
+{
+    public static var live: Environment
+    {
+        /// Effectful references.
+        class Refs {
+            var player: AVPlayer?
+        }
+
+        let refs = Refs()
+
+        return .init(
+            getPlayer: { refs.player },
+            setPlayer: { refs.player = $0 }
+        )
+    }
+}

--- a/Sources/VideoPlayer/VideoPlayer.swift
+++ b/Sources/VideoPlayer/VideoPlayer.swift
@@ -1,0 +1,138 @@
+import UIKit
+import Combine
+import AVFoundation
+import Actomaton
+import ActomatonDebugging
+import Utilities
+
+#if swift(>=5.6)
+@preconcurrency import AVFoundation_Combine
+#else
+import AVFoundation_Combine
+extension PlayingStatus: @unchecked Sendable {}
+#endif
+
+// MARK: - Action
+
+public enum Action: Sendable
+{
+    case subscribePlayer
+    case start
+    case stop
+    case backward(seconds: TimeInterval)
+    case forward(seconds: TimeInterval)
+    case seek(to: TimeInterval)
+
+    case _updatePlayingStatus(PlayingStatus)
+}
+
+// MARK: - State
+
+public struct State: Equatable, Sendable
+{
+    let label: String
+
+    var playingStatus: PlayingStatus = .unknown
+
+    public init(label: String)
+    {
+        self.label = label
+    }
+}
+
+// MARK: - Environment
+
+public struct Environment: Sendable
+{
+    public let getPlayer: @Sendable () -> AVPlayer?
+    public let setPlayer: @Sendable (AVPlayer?) -> Void
+
+    public init(
+        getPlayer: @Sendable @escaping () -> AVPlayer?,
+        setPlayer: @Sendable @escaping (AVPlayer?) -> Void
+    )
+    {
+        self.getPlayer = getPlayer
+        self.setPlayer = setPlayer
+    }
+}
+
+// MARK: - EffectQueue
+
+/// Player observation queue per each `label`, with old subscription auto-cancellation.
+public struct PlayerSubscriptionQueue: Newest1EffectQueueProtocol
+{
+    /// Label used to identify a video player in case of multiple players being presented at same time,
+    /// but each player's subscription (effect) should not interfere with each other.
+    let label: String
+}
+
+// MARK: - Reducer
+
+public var reducer: Reducer<Action, State, Environment>
+{
+    .debug(name: "===> VideoPlayer") { action, state, environment in
+        switch action {
+        case .subscribePlayer:
+            return Effect(
+                queue: PlayerSubscriptionQueue(label: state.label),
+                sequence: { @MainActor () -> AsyncStream<Action> in
+                    guard let player = environment.getPlayer() else {
+                        return AsyncStream(unfolding: { nil })
+                    }
+
+                    return player.playingStatusPublisher
+                        .map(Action._updatePlayingStatus)
+                        .toAsyncStream()
+                }
+            )
+
+        case .start:
+            return Effect.fireAndForget { @MainActor in
+                guard let player = environment.getPlayer() else { return }
+                player.play()
+            }
+
+        case .stop:
+            return Effect.fireAndForget { @MainActor in
+                guard let player = environment.getPlayer() else { return }
+                player.pause()
+            }
+
+        case let .backward(seconds):
+            return Effect.fireAndForget { @MainActor in
+                guard let player = environment.getPlayer() else { return }
+
+                let currentTime = player.currentTime()
+
+                player.seek(to: currentTime - CMTime(seconds: seconds, preferredTimescale: 1)) { success in
+                    print("seek backward", success)
+                }
+            }
+
+        case let .forward(seconds):
+            return Effect.fireAndForget { @MainActor in
+                guard let player = environment.getPlayer() else { return }
+
+                let currentTime = player.currentTime()
+
+                player.seek(to: currentTime + CMTime(seconds: seconds, preferredTimescale: 1)) { success in
+                    print("seek forward", success)
+                }
+            }
+
+        case let .seek(to: seconds):
+            return Effect.fireAndForget { @MainActor in
+                guard let player = environment.getPlayer() else { return }
+
+                player.seek(to: CMTime(seconds: seconds, preferredTimescale: 1)) { success in
+                    print("seek to", success)
+                }
+            }
+
+        case let ._updatePlayingStatus(playingStatus):
+            state.playingStatus = playingStatus
+            return .empty
+        }
+    }
+}

--- a/Sources/VideoPlayer/VideoPlayerView.swift
+++ b/Sources/VideoPlayer/VideoPlayerView.swift
@@ -1,0 +1,51 @@
+import AVFoundation
+import SwiftUI
+import AVKit
+import ActomatonStore
+
+@MainActor
+public struct VideoPlayerView: View
+{
+    private let store: Store<Action, State, Environment>.Proxy
+
+    public init(store: Store<Action, State, Environment>.Proxy)
+    {
+        self.store = store
+    }
+
+    public var body: some View
+    {
+        VStack(spacing: 16) {
+            AVKit.VideoPlayer(player: store.environment.getPlayer())
+                .background(Color.black)
+
+            controlsView
+        }
+    }
+
+    @ViewBuilder
+    private var controlsView: some View
+    {
+        HStack(spacing: 16) {
+            Button(action: { store.send(.backward(seconds: 5)) }) {
+                Image(systemName: "gobackward.5")
+            }
+
+            if store.state.playingStatus == .paused || store.state.playingStatus == .unknown {
+                Button(action: { store.send(.start) }) {
+                    Image(systemName: "play.circle")
+                }
+            }
+            else {
+                Button(action: { store.send(.stop) }) {
+                    Image(systemName: "pause.circle")
+                }
+            }
+
+            Button(action: { store.send(.forward(seconds: 5)) }) {
+                Image(systemName: "goforward.5")
+            }
+        }
+        .font(.largeTitle)
+    }
+}

--- a/Sources/VideoPlayerMulti/VideoPlayerMulti.Environment.live.swift
+++ b/Sources/VideoPlayerMulti/VideoPlayerMulti.Environment.live.swift
@@ -1,0 +1,18 @@
+import VideoPlayer
+
+extension Environment
+{
+    /// Live environment that separates `AVPlayer` per each `VideoPlayer` module.
+    public static var live: Environment
+    {
+        // NOTE: Creates different `.live` `AVPlayer` environment for each player.
+        let environment1 = VideoPlayer.Environment.live
+        let environment2 = VideoPlayer.Environment.live
+
+        return Environment(
+            description: "Multiple AVPlayers",
+            videoPlayer1: environment1,
+            videoPlayer2: environment2
+        )
+    }
+}

--- a/Sources/VideoPlayerMulti/VideoPlayerMulti.swift
+++ b/Sources/VideoPlayerMulti/VideoPlayerMulti.swift
@@ -1,0 +1,88 @@
+import UIKit
+import Combine
+import AVFoundation
+import Actomaton
+import ActomatonDebugging
+import VideoPlayer
+
+// MARK: - Action
+
+public enum Action: Sendable
+{
+    case videoPlayer1(VideoPlayer.Action)
+    case videoPlayer2(VideoPlayer.Action)
+}
+
+// MARK: - State
+
+public struct State: Equatable, Sendable
+{
+    var displayMode: DisplayMode
+
+    var videoPlayer1: VideoPlayer.State = .init(label: "videoPlayer1")
+    var videoPlayer2: VideoPlayer.State = .init(label: "videoPlayer2")
+
+    public init(displayMode: DisplayMode)
+    {
+        self.displayMode = displayMode
+    }
+
+    public enum DisplayMode: String, Equatable, Sendable
+    {
+        case singleSyncedPlayer
+        case multiplePlayers
+    }
+}
+
+// MARK: - Environment
+
+public struct Environment: Sendable
+{
+    let description: String
+    let videoPlayer1: VideoPlayer.Environment
+    let videoPlayer2: VideoPlayer.Environment
+
+    public init(
+        description: String,
+        videoPlayer1: VideoPlayer.Environment,
+        videoPlayer2: VideoPlayer.Environment
+    )
+    {
+        self.description = description
+        self.videoPlayer1 = videoPlayer1
+        self.videoPlayer2 = videoPlayer2
+    }
+}
+
+// MARK: - Reducer
+
+public var reducer: Reducer<Action, State, Environment>
+{
+    return .init { action, state, environment in
+        _reducer(mode: state.displayMode)
+            .run(action, &state, environment)
+    }
+}
+
+private func _reducer(mode: State.DisplayMode) -> Reducer<Action, State, Environment>
+{
+    Reducer.combine(
+        VideoPlayer.reducer
+            .contramap(action: /Action.videoPlayer1)
+            .contramap(state: \.videoPlayer1)
+            .contramap(environment: \.videoPlayer1),
+
+        VideoPlayer.reducer
+            .contramap(action: /Action.videoPlayer2)
+            .contramap(state: \.videoPlayer2)
+            .contramap(environment: {
+                // Environment switching.
+                switch mode {
+                case .singleSyncedPlayer:
+                    return \.videoPlayer1 // Use same environment as `videoPlayer1`.
+                case .multiplePlayers:
+                    return \.videoPlayer2
+                }
+            }())
+    )
+}

--- a/Sources/VideoPlayerMulti/VideoPlayerMultiView.swift
+++ b/Sources/VideoPlayerMulti/VideoPlayerMultiView.swift
@@ -1,0 +1,85 @@
+import AVFoundation
+import SwiftUI
+import ActomatonStore
+import VideoPlayer
+
+@MainActor
+public struct VideoPlayerMultiView: View
+{
+    private let store: Store<Action, State, Environment>.Proxy
+
+    @SwiftUI.State private var isInitial: Bool = true
+
+    public init(store: Store<Action, State, Environment>.Proxy)
+    {
+        self.store = store
+    }
+
+    public var body: some View
+    {
+        let childStore1 = store.videoPlayer1
+            .contramap(action: Action.videoPlayer1)
+            .map(environment: \.videoPlayer1)
+
+        let childStore2 = store.videoPlayer2
+            .contramap(action: Action.videoPlayer2)
+            .map(environment: { () -> (Environment) -> VideoPlayer.Environment in
+                switch store.state.displayMode {
+                case .singleSyncedPlayer:
+                    return \.videoPlayer1
+                case .multiplePlayers:
+                    return \.videoPlayer2
+                }
+            }())
+
+        VStack(spacing: 16) {
+            Picker("", selection: store.$state.displayMode) {
+                Text("Single Synced Player")
+                    .tag(State.DisplayMode.singleSyncedPlayer)
+                Text("Multiple Players")
+                    .tag(State.DisplayMode.multiplePlayers)
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .padding()
+
+            videoPlayerView(childStore: childStore1)
+            videoPlayerView(childStore: childStore2)
+        }
+        .onAppear {
+            if isInitial {
+                isInitial = false
+
+                store.environment.videoPlayer1.setPlayer(makePlayer())
+                store.environment.videoPlayer2.setPlayer(makePlayer())
+            }
+        }
+        .onChange(of: store.state.displayMode) { _ in
+            // Re-subscribe each player on `displayMode` changes.
+            childStore1.send(.subscribePlayer)
+            childStore2.send(.subscribePlayer)
+        }
+    }
+
+    @ViewBuilder
+    private func videoPlayerView(
+        childStore: Store<VideoPlayer.Action, VideoPlayer.State, VideoPlayer.Environment>.Proxy
+    ) -> some View
+    {
+        VideoPlayerView(store: childStore)
+            .onAppear {
+                childStore.send(.subscribePlayer)
+                childStore.send(.start)
+            }
+            .onDisappear {
+                childStore.send(.stop)
+            }
+    }
+}
+
+// MARK: - Private
+
+private func makePlayer() -> AVPlayer {
+    let urlString = "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8"
+    let player = AVPlayer(url: URL(string: urlString)!)
+    return player
+}


### PR DESCRIPTION
Successor of:
- https://github.com/inamiy/Actomaton-Gallery/pull/35

Implementation of:
- https://github.com/inamiy/Actomaton/pull/36

This PR adds VideoPlayer & VideoPlayerMulti examples to show how `AVPlayer`(s) can be injected and switched through`Environment` and accessed via `store.environment`, which is introduced in https://github.com/inamiy/Actomaton/pull/36 .

## Screencast

https://user-images.githubusercontent.com/138476/159212092-eb6a7fc2-3423-4d15-9fa5-81f595d97d81.mp4



