### PR TITLE
Add Actomaton-VideoPlayer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Build Favorite-Sync
       run: make build-Favorite-Sync
 
-  build-Favorite-Sync:
+  build-VideoPlayer:
     runs-on: macos-11
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,3 +40,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Favorite-Sync
       run: make build-Favorite-Sync
+
+  build-Favorite-Sync:
+    runs-on: macos-11
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build VideoPlayer
+      run: make build-VideoPlayer

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.pbxproj
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.pbxproj
@@ -1,0 +1,487 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		330DF51A278F1CD10084A751 /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 330DF519278F1CD10084A751 /* CombineCocoa */; };
+		331BD25027EB5E3000E5A288 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331BD24F27EB5E3000E5A288 /* RootView.swift */; };
+		339D629027EB608B00CCFEE5 /* AVFoundation-Combine in Frameworks */ = {isa = PBXBuildFile; productRef = 339D628F27EB608B00CCFEE5 /* AVFoundation-Combine */; };
+		339D629227EB60D100CCFEE5 /* UncheckedSendable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339D629127EB60D100CCFEE5 /* UncheckedSendable.swift */; };
+		339D629627EB61FD00CCFEE5 /* AVFoundation+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339D629527EB61FD00CCFEE5 /* AVFoundation+Extensions.swift */; };
+		339D629827EB625D00CCFEE5 /* Foundation+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339D629727EB625D00CCFEE5 /* Foundation+Extensions.swift */; };
+		339D629C27EB68B700CCFEE5 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339D629B27EB68B700CCFEE5 /* Constants.swift */; };
+		339D62A027EB6D7000CCFEE5 /* PlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339D629F27EB6D7000CCFEE5 /* PlayerState.swift */; };
+		33C59F2127ECC3280090BD9F /* PlayerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C59F2027ECC3280090BD9F /* PlayerAction.swift */; };
+		33C97A3927ED52AD00CF7F96 /* RootState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C97A3527ED52AD00CF7F96 /* RootState.swift */; };
+		33C97A3A27ED52AD00CF7F96 /* RootReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C97A3627ED52AD00CF7F96 /* RootReducer.swift */; };
+		33C97A3B27ED52AD00CF7F96 /* RootEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C97A3727ED52AD00CF7F96 /* RootEnvironment.swift */; };
+		33C97A3C27ED52AD00CF7F96 /* RootAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C97A3827ED52AD00CF7F96 /* RootAction.swift */; };
+		33D7DA0E278961EC00B362ED /* MyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7DA0D278961EC00B362ED /* MyApp.swift */; };
+		33D7DA12278961ED00B362ED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33D7DA11278961ED00B362ED /* Assets.xcassets */; };
+		33D7DA15278961ED00B362ED /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33D7DA14278961ED00B362ED /* Preview Assets.xcassets */; };
+		33D7DA1D2789626500B362ED /* ActomatonStore in Frameworks */ = {isa = PBXBuildFile; productRef = 33D7DA1C2789626500B362ED /* ActomatonStore */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		331BD24F27EB5E3000E5A288 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		339D629127EB60D100CCFEE5 /* UncheckedSendable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UncheckedSendable.swift; sourceTree = "<group>"; };
+		339D629527EB61FD00CCFEE5 /* AVFoundation+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVFoundation+Extensions.swift"; sourceTree = "<group>"; };
+		339D629727EB625D00CCFEE5 /* Foundation+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+Extensions.swift"; sourceTree = "<group>"; };
+		339D629B27EB68B700CCFEE5 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		339D629D27EB69FA00CCFEE5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		339D629F27EB6D7000CCFEE5 /* PlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerState.swift; sourceTree = "<group>"; };
+		33C59F2027ECC3280090BD9F /* PlayerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerAction.swift; sourceTree = "<group>"; };
+		33C97A3527ED52AD00CF7F96 /* RootState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootState.swift; sourceTree = "<group>"; };
+		33C97A3627ED52AD00CF7F96 /* RootReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootReducer.swift; sourceTree = "<group>"; };
+		33C97A3727ED52AD00CF7F96 /* RootEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootEnvironment.swift; sourceTree = "<group>"; };
+		33C97A3827ED52AD00CF7F96 /* RootAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootAction.swift; sourceTree = "<group>"; };
+		33D7DA0A278961EC00B362ED /* Actomaton-VideoPlayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Actomaton-VideoPlayer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33D7DA0D278961EC00B362ED /* MyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyApp.swift; sourceTree = "<group>"; };
+		33D7DA11278961ED00B362ED /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		33D7DA14278961ED00B362ED /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		33D7DA07278961EC00B362ED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				339D629027EB608B00CCFEE5 /* AVFoundation-Combine in Frameworks */,
+				330DF51A278F1CD10084A751 /* CombineCocoa in Frameworks */,
+				33D7DA1D2789626500B362ED /* ActomatonStore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		338CAD7E27ECD40F00E2EEED /* Root */ = {
+			isa = PBXGroup;
+			children = (
+				33C97A3827ED52AD00CF7F96 /* RootAction.swift */,
+				33C97A3727ED52AD00CF7F96 /* RootEnvironment.swift */,
+				33C97A3627ED52AD00CF7F96 /* RootReducer.swift */,
+				33C97A3527ED52AD00CF7F96 /* RootState.swift */,
+				331BD24F27EB5E3000E5A288 /* RootView.swift */,
+			);
+			path = Root;
+			sourceTree = "<group>";
+		};
+		339D628E27EB608B00CCFEE5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		339D629E27EB6A2E00CCFEE5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				339D629727EB625D00CCFEE5 /* Foundation+Extensions.swift */,
+				339D629527EB61FD00CCFEE5 /* AVFoundation+Extensions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		339D62A127EB6E6000CCFEE5 /* Player */ = {
+			isa = PBXGroup;
+			children = (
+				33C59F2027ECC3280090BD9F /* PlayerAction.swift */,
+				339D629F27EB6D7000CCFEE5 /* PlayerState.swift */,
+			);
+			path = Player;
+			sourceTree = "<group>";
+		};
+		33D7DA01278961EC00B362ED = {
+			isa = PBXGroup;
+			children = (
+				33D7DA0C278961EC00B362ED /* Actomaton-VideoPlayer */,
+				33D7DA0B278961EC00B362ED /* Products */,
+				339D628E27EB608B00CCFEE5 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		33D7DA0B278961EC00B362ED /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA0A278961EC00B362ED /* Actomaton-VideoPlayer.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		33D7DA0C278961EC00B362ED /* Actomaton-VideoPlayer */ = {
+			isa = PBXGroup;
+			children = (
+				339D629E27EB6A2E00CCFEE5 /* Extensions */,
+				338CAD7E27ECD40F00E2EEED /* Root */,
+				339D62A127EB6E6000CCFEE5 /* Player */,
+				33D7DA0D278961EC00B362ED /* MyApp.swift */,
+				339D629B27EB68B700CCFEE5 /* Constants.swift */,
+				339D629127EB60D100CCFEE5 /* UncheckedSendable.swift */,
+				33D7DA11278961ED00B362ED /* Assets.xcassets */,
+				33D7DA13278961ED00B362ED /* Preview Content */,
+				339D629D27EB69FA00CCFEE5 /* Info.plist */,
+			);
+			path = "Actomaton-VideoPlayer";
+			sourceTree = "<group>";
+		};
+		33D7DA13278961ED00B362ED /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				33D7DA14278961ED00B362ED /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		33D7DA09278961EC00B362ED /* Actomaton-VideoPlayer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 33D7DA18278961ED00B362ED /* Build configuration list for PBXNativeTarget "Actomaton-VideoPlayer" */;
+			buildPhases = (
+				33D7DA06278961EC00B362ED /* Sources */,
+				33D7DA07278961EC00B362ED /* Frameworks */,
+				33D7DA08278961EC00B362ED /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Actomaton-VideoPlayer";
+			packageProductDependencies = (
+				33D7DA1C2789626500B362ED /* ActomatonStore */,
+				330DF519278F1CD10084A751 /* CombineCocoa */,
+				339D628F27EB608B00CCFEE5 /* AVFoundation-Combine */,
+			);
+			productName = "Actomaton-VideoPlayer";
+			productReference = 33D7DA0A278961EC00B362ED /* Actomaton-VideoPlayer.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		33D7DA02278961EC00B362ED /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					33D7DA09278961EC00B362ED = {
+						CreatedOnToolsVersion = 13.2;
+					};
+				};
+			};
+			buildConfigurationList = 33D7DA05278961EC00B362ED /* Build configuration list for PBXProject "Actomaton-VideoPlayer" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 33D7DA01278961EC00B362ED;
+			packageReferences = (
+				33D7DA1B2789626500B362ED /* XCRemoteSwiftPackageReference "Actomaton" */,
+				330DF518278F1CD10084A751 /* XCRemoteSwiftPackageReference "CombineCocoa" */,
+				33601F5027EB5DAB00C6D1AA /* XCRemoteSwiftPackageReference "AVFoundation-Combine" */,
+			);
+			productRefGroup = 33D7DA0B278961EC00B362ED /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				33D7DA09278961EC00B362ED /* Actomaton-VideoPlayer */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		33D7DA08278961EC00B362ED /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33D7DA15278961ED00B362ED /* Preview Assets.xcassets in Resources */,
+				33D7DA12278961ED00B362ED /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		33D7DA06278961EC00B362ED /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				339D62A027EB6D7000CCFEE5 /* PlayerState.swift in Sources */,
+				33C97A3C27ED52AD00CF7F96 /* RootAction.swift in Sources */,
+				33C97A3B27ED52AD00CF7F96 /* RootEnvironment.swift in Sources */,
+				33D7DA0E278961EC00B362ED /* MyApp.swift in Sources */,
+				331BD25027EB5E3000E5A288 /* RootView.swift in Sources */,
+				339D629227EB60D100CCFEE5 /* UncheckedSendable.swift in Sources */,
+				339D629827EB625D00CCFEE5 /* Foundation+Extensions.swift in Sources */,
+				33C97A3927ED52AD00CF7F96 /* RootState.swift in Sources */,
+				339D629627EB61FD00CCFEE5 /* AVFoundation+Extensions.swift in Sources */,
+				33C59F2127ECC3280090BD9F /* PlayerAction.swift in Sources */,
+				339D629C27EB68B700CCFEE5 /* Constants.swift in Sources */,
+				33C97A3A27ED52AD00CF7F96 /* RootReducer.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		33D7DA16278961ED00B362ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		33D7DA17278961ED00B362ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		33D7DA19278961ED00B362ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Actomaton-VideoPlayer/Preview Content\"";
+				DEVELOPMENT_TEAM = UMBZ5WL247;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Actomaton-VideoPlayer/Info.plist";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-concurrency -Xfrontend -enable-actor-data-race-checks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.Actomaton-VideoPlayer";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		33D7DA1A278961ED00B362ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Actomaton-VideoPlayer/Preview Content\"";
+				DEVELOPMENT_TEAM = UMBZ5WL247;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Actomaton-VideoPlayer/Info.plist";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-concurrency -Xfrontend -enable-actor-data-race-checks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.inamiy.Actomaton-VideoPlayer";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		33D7DA05278961EC00B362ED /* Build configuration list for PBXProject "Actomaton-VideoPlayer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33D7DA16278961ED00B362ED /* Debug */,
+				33D7DA17278961ED00B362ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		33D7DA18278961ED00B362ED /* Build configuration list for PBXNativeTarget "Actomaton-VideoPlayer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33D7DA19278961ED00B362ED /* Debug */,
+				33D7DA1A278961ED00B362ED /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		330DF518278F1CD10084A751 /* XCRemoteSwiftPackageReference "CombineCocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CombineCommunity/CombineCocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.0;
+			};
+		};
+		33601F5027EB5DAB00C6D1AA /* XCRemoteSwiftPackageReference "AVFoundation-Combine" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/inamiy/AVFoundation-Combine";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
+		33D7DA1B2789626500B362ED /* XCRemoteSwiftPackageReference "Actomaton" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/inamiy/Actomaton";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		330DF519278F1CD10084A751 /* CombineCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 330DF518278F1CD10084A751 /* XCRemoteSwiftPackageReference "CombineCocoa" */;
+			productName = CombineCocoa;
+		};
+		339D628F27EB608B00CCFEE5 /* AVFoundation-Combine */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 33601F5027EB5DAB00C6D1AA /* XCRemoteSwiftPackageReference "AVFoundation-Combine" */;
+			productName = "AVFoundation-Combine";
+		};
+		33D7DA1C2789626500B362ED /* ActomatonStore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 33D7DA1B2789626500B362ED /* XCRemoteSwiftPackageReference "Actomaton" */;
+			productName = ActomatonStore;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 33D7DA02278961EC00B362ED /* Project object */;
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,59 +1,61 @@
 {
-  "pins" : [
-    {
-      "identity" : "actomaton",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inamiy/Actomaton",
-      "state" : {
-        "branch" : "main",
-        "revision" : "2cef51434218713343f3b8e3d2d3a70b3832b272"
+  "object": {
+    "pins": [
+      {
+        "package": "Actomaton",
+        "repositoryURL": "https://github.com/inamiy/Actomaton",
+        "state": {
+          "branch": "main",
+          "revision": "96f664f6ff98ddbc524403e10734f40861ec12a8",
+          "version": null
+        }
+      },
+      {
+        "package": "AVFoundation-Combine",
+        "repositoryURL": "https://github.com/inamiy/AVFoundation-Combine",
+        "state": {
+          "branch": null,
+          "revision": "637ba786561616297554365d12402414d5024335",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "CombineCocoa",
+        "repositoryURL": "https://github.com/CombineCommunity/CombineCocoa",
+        "state": {
+          "branch": null,
+          "revision": "4e262c2f9fb1cee1cb3be5717f7e6b55eb823971",
+          "version": "0.4.0"
+        }
+      },
+      {
+        "package": "swift-case-paths",
+        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
+        "state": {
+          "branch": null,
+          "revision": "241301b67d8551c26d8f09bd2c0e52cc49f18007",
+          "version": "0.8.0"
+        }
+      },
+      {
+        "package": "swift-custom-dump",
+        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
+        "state": {
+          "branch": null,
+          "revision": "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
+          "version": "0.2.1"
+        }
       }
-    },
-    {
-      "identity" : "avfoundation-combine",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inamiy/AVFoundation-Combine",
-      "state" : {
-        "revision" : "637ba786561616297554365d12402414d5024335",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "combinecocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CombineCommunity/CombineCocoa",
-      "state" : {
-        "revision" : "4e262c2f9fb1cee1cb3be5717f7e6b55eb823971",
-        "version" : "0.4.0"
-      }
-    },
-    {
-      "identity" : "swift-case-paths",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
-      "state" : {
-        "revision" : "241301b67d8551c26d8f09bd2c0e52cc49f18007",
-        "version" : "0.8.0"
-      }
-    },
-    {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
-        "version" : "0.3.0"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "50a70a9d3583fe228ce672e8923010c8df2deddd",
-        "version" : "0.2.1"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,59 @@
+{
+  "pins" : [
+    {
+      "identity" : "actomaton",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/Actomaton",
+      "state" : {
+        "branch" : "main",
+        "revision" : "2cef51434218713343f3b8e3d2d3a70b3832b272"
+      }
+    },
+    {
+      "identity" : "avfoundation-combine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/AVFoundation-Combine",
+      "state" : {
+        "revision" : "637ba786561616297554365d12402414d5024335",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "combinecocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CombineCommunity/CombineCocoa",
+      "state" : {
+        "revision" : "4e262c2f9fb1cee1cb3be5717f7e6b55eb823971",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "241301b67d8551c26d8f09bd2c0e52cc49f18007",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "51698ece74ecf31959d3fa81733f0a5363ef1b4e",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "50a70a9d3583fe228ce672e8923010c8df2deddd",
+        "version" : "0.2.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Assets.xcassets/Contents.json
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Constants.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Constants.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum Constants
+{
+    static let videoURLs: [URL] = [
+        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
+        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4",
+        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4",
+        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4",
+        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4",
+        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerMeltdowns.mp4",
+        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4",
+        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4",
+    ]
+        .compactMap { URL(string: $0) }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Extensions/AVFoundation+Extensions.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Extensions/AVFoundation+Extensions.swift
@@ -1,0 +1,77 @@
+import AVFoundation
+
+// MARK: - LogEvent descriptionDictionary
+
+extension AVPlayerItemAccessLogEvent
+{
+    public var descriptionDictionary: [String: Any]
+    {
+        var output = [String: Any]()
+        output["numberOfMediaRequests"] = numberOfMediaRequests
+        output["playbackStartDate"] = playbackStartDate?.description ?? ""
+        output["uri"] = uri ?? ""
+        output["serverAddress"] = serverAddress ?? ""
+        output["numberOfServerAddressChanges"] = numberOfServerAddressChanges
+        output["playbackSessionID"] = playbackSessionID ?? ""
+        output["playbackStartOffset"] = playbackStartOffset
+        output["segmentsDownloadedDuration"] = segmentsDownloadedDuration
+        output["durationWatched"] = durationWatched
+        output["numberOfStalls"] = numberOfStalls
+        output["numberOfBytesTransferred"] = Int(numberOfBytesTransferred)
+        output["transferDuration"] = transferDuration
+        output["observedBitrate"] = observedBitrate
+        output["indicatedBitrate"] = indicatedBitrate
+        output["numberOfDroppedVideoFrames"] = numberOfDroppedVideoFrames
+        output["startupTime"] = startupTime
+        output["downloadOverdue"] = downloadOverdue
+        output["observedMaxBitrate"] = observedMaxBitrate
+        output["observedMinBitrate"] = observedMinBitrate
+        output["observedBitrateStandardDeviation"] = observedBitrateStandardDeviation
+        output["playbackType"] = playbackType
+        output["mediaRequestsWWAN"] = mediaRequestsWWAN
+        output["switchBitrate"] = switchBitrate
+        return output
+    }
+}
+
+extension AVPlayerItemErrorLogEvent
+{
+    public var descriptionDictionary: [String: Any]
+    {
+        var output = [String: Any]()
+        output["date"] = date ?? ""
+        output["uri"] = uri ?? ""
+        output["serverAddress"] = serverAddress ?? ""
+        output["playbackSessionID"] = playbackSessionID ?? ""
+        output["errorStatusCode"] = errorStatusCode
+        output["errorDomain"] = errorDomain
+        output["errorComment"] = errorComment ?? ""
+        return output
+    }
+}
+
+// MARK: - Log extendedLogString
+
+extension AVPlayerItemAccessLog
+{
+    open var extendedLogString: String?
+    {
+        guard let data = extendedLogData(),
+              let string = String(data: data, encoding: .init(rawValue: extendedLogDataStringEncoding))
+        else { return nil }
+
+        return string
+    }
+}
+
+extension AVPlayerItemErrorLog
+{
+    open var extendedLogString: String?
+    {
+        guard let data = extendedLogData(),
+              let string = String(data: data, encoding: .init(rawValue: extendedLogDataStringEncoding))
+        else { return nil }
+
+        return string
+    }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Extensions/Foundation+Extensions.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Extensions/Foundation+Extensions.swift
@@ -1,0 +1,34 @@
+import AVFoundation
+import Foundation
+
+extension CMTimeRange: CustomStringConvertible
+{
+    public var description: String
+    {
+        "\(round(start.seconds * 10) / 10)s ~ \(round(end.seconds * 10) / 10)s"
+    }
+}
+
+extension String: Identifiable
+{
+    public var id: String
+    {
+        self
+    }
+}
+
+extension String
+{
+    /// https://stackoverflow.com/questions/39488488/unescaping-backslash-in-swift/39489337
+    var unescaped: String
+    {
+        let entities = ["\0", "\t", "\n", "\r", "\"", "\'", "\\"]
+        var current = self
+        for entity in entities {
+            let descriptionCharacters = entity.debugDescription.dropFirst().dropLast()
+            let description = String(descriptionCharacters)
+            current = current.replacingOccurrences(of: description, with: entity)
+        }
+        return current
+    }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Info.plist
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/MyApp.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/MyApp.swift
@@ -1,0 +1,42 @@
+import AVFoundation
+import SwiftUI
+import UIKit
+import ActomatonStore
+
+@MainActor
+@main
+struct MyApp: App
+{
+    @StateObject
+    private var store: Store<RootAction, RootState, RootEnvironment>
+
+    init()
+    {
+        @MainActor
+        class Player: Sendable {
+            let avPlayer = AVPlayer()
+        }
+
+        let player = Player()
+
+        self._store = StateObject(
+            wrappedValue: Store(
+                state: .init(),
+                reducer: rootReducer(),
+                environment: RootEnvironment(
+                    getPlayer: { player.avPlayer },
+                    getRandomVideoURL: { Constants.videoURLs.randomElement()! }
+                )
+            )
+        )
+    }
+
+    var body: some Scene
+    {
+        WindowGroup {
+            ZStack(alignment: .bottomTrailing) {
+                RootView(store: store.proxy)
+            }
+        }
+    }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Player/PlayerAction.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Player/PlayerAction.swift
@@ -1,0 +1,33 @@
+import AVFoundation
+import AVFoundation_Combine
+
+enum PlayerAction: Sendable
+{
+    // AVPlayer
+    case periodicTime(CMTime)
+    case playingStatus(PlayingStatus)
+    case playerRate(Float)
+
+    // AVAudioSession
+    case outputVolume(Float)
+
+    // AVPlayerItem
+    case playerItemStatus(AVPlayerItem.Status)
+    case playerItemError(String)
+    case timebaseRate(Double)
+    case timeJumped
+    case loadedTimeRanges([CMTimeRange])
+    case seekableTimeRanges([CMTimeRange])
+    case didPlayEndToTime
+    case failedToPlayToEndTime(String)
+    case isPlaybackLikelyToKeepUp(Bool)
+    case playbackBufferState(PlaybackBufferState)
+    case playbackStalled
+    case timedMetadataGroups([AVTimedMetadataGroup])
+    case newAccessLogEvent(AVPlayerItemAccessLogEvent)
+    case newErrorLogEvent(AVPlayerItemErrorLogEvent)
+
+    // AVAsset
+    case isPlayable(Bool)
+    case duration(TimeInterval)
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Player/PlayerState.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Player/PlayerState.swift
@@ -1,0 +1,62 @@
+import Foundation
+import AVFoundation
+import Combine
+import AVFoundation_Combine
+
+/// `AVPlayer` state representation for debuggable demo with reflection-printing via ``mirroredChildren``.
+struct PlayerState: Equatable, Sendable
+{
+    var assetInitTime: TimeInterval = 0
+    var playerItemInitTime: TimeInterval = 0
+    var playerItemReplacedTime: TimeInterval = 0
+
+    var playerItemStatus: AVPlayerItem.Status = .unknown
+    var playingStatus: PlayingStatus = .unknown
+    var isPlayable: Bool = false
+    var playbackBufferState: PlaybackBufferState = .empty
+    var isPlaybackLikelyToKeepUp: Bool = false
+    var loadedTimeRanges: [CMTimeRange] = []
+    var seekableTimeRanges: [CMTimeRange] = []
+
+    var currentTime: TimeInterval = .nan
+    var duration: TimeInterval = .nan
+    var playerRate: Float = .nan
+    var timebaseRate: Double = .nan
+    var outputVolume: Float = .nan
+    var errorString: String?
+
+    var playbackStalled: Notification?
+    var timedMetadataGroups: [AVTimedMetadataGroup] = []
+    var newAccessLogEvent: String? // AVPlayerItemAccessLogEvent?
+    var newErrorLogEvent: String?  // AVPlayerItemErrorLogEvent?
+
+    var mirroredChildren: [(label: String, value: String)]
+    {
+        Mirror(reflecting: self).children
+            .compactMap { label, value in
+                label.map { ($0, String(describing: value)) }
+            }
+            .map { label, value in
+                let value2 = value.replacingOccurrences(
+                    of: "Optional\\((.*)\\)",
+                    with: "$1",
+                    options: .regularExpression
+                )
+                guard let value1 = Double(value2) else {
+                    return (label, value2)
+                }
+                // If value is floating point, use `shortFloatingDescription`.
+                return (label, value1.shortFloatingDescription)
+            }
+    }
+}
+
+extension FloatingPoint
+{
+    fileprivate var shortFloatingDescription: String
+    {
+        let factor: Self = 10000
+        let value = (self * factor).rounded() / factor
+        return "\(value)"
+    }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootAction.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootAction.swift
@@ -1,0 +1,35 @@
+import AVFoundation
+import Combine
+import SwiftUI
+import AVFoundation_Combine
+
+enum RootAction: Sendable
+{
+    // Reload
+    case reloadRandom
+    case _reload(URL?)
+
+    case _subscribePlayerAfterReload(
+        assetInitTime: CFAbsoluteTime,
+        playerItemInitTime: CFAbsoluteTime,
+        playerItemReplacedTime: CFAbsoluteTime,
+        wasPaused: Bool
+    )
+
+    // Player control.
+    case play
+    case pause
+    case advance(seconds: TimeInterval)
+
+    // Slider seek.
+    case updateSliderValue(Float)
+    case didFinishSliderSeeking
+    case _didFinishPlayerSeeking(seekingTime: TimeInterval, wasPaused: Bool)
+
+    // Dialog.
+    case showDialog(label: String, value: String)
+    case closeDialog
+
+    // Inner Player actions.
+    case _playerAction(PlayerAction)
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootEnvironment.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootEnvironment.swift
@@ -1,0 +1,170 @@
+import AVFoundation
+import Combine
+import SwiftUI
+import Actomaton
+
+struct RootEnvironment: Sendable
+{
+    let getPlayer: @MainActor @Sendable () -> AVPlayer?
+    let getRandomVideoURL: @Sendable () -> URL?
+}
+
+extension RootEnvironment
+{
+    var playerSubscriptionEffect: Effect<PlayerAction>
+    {
+        Effect(
+            queue: PlayerSubscriptionEffectQueue(),
+            sequence: { @MainActor () -> AsyncStream<PlayerAction> in
+                guard let player = self.getPlayer() else {
+                    return AsyncStream(unfolding: { nil })
+                }
+
+                let playerPublishers: [AnyPublisher<PlayerAction, Never>] = [
+                    player.periodicTimePublisher(interval: CMTime(seconds: 0.1, preferredTimescale: 100))
+                        .map { .periodicTime($0) }
+                        .eraseToAnyPublisher(),
+
+                    player
+                        .boundaryTimePublisher(
+                            times: (1 ... 3).map { CMTime(seconds: Double($0), preferredTimescale: 100) }
+                        )
+                        .print("boundaryTime")
+                        .flatMap { Combine.Empty<PlayerAction, Never>(completeImmediately: true) }
+                        .eraseToAnyPublisher(),
+
+                    player.playingStatusPublisher
+                        .map { .playingStatus($0) }
+                        .eraseToAnyPublisher(),
+
+                    player.ratePublisher
+                        .map { .playerRate($0) }
+                        .eraseToAnyPublisher()
+                ]
+
+                let playerItemPublishers: [AnyPublisher<PlayerAction, Never>] = {
+                    guard let currentItem = player.currentItem else { return [] }
+
+                    return [
+                        currentItem.statusPublisher
+                            .map { .playerItemStatus($0) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.errorPublisher
+                            .map { .playerItemError(String(describing: $0)) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.timebaseRatePublisher
+                            .receive(on: DispatchQueue.main) // Required for @MainActor data-race detection.
+                            .map { .timebaseRate($0) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.timeJumpedPublisher
+                            .map { _ in .timeJumped }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.playbackStalledPublisher
+                            .map { _ in .playbackStalled }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.loadedTimeRangesPublisher
+                            .map { .loadedTimeRanges($0) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.seekableTimeRangesPublisher
+                            .map { .seekableTimeRanges($0) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.didPlayEndToTimePublisher
+                            .map { _ in .didPlayEndToTime }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.failedToPlayToEndTimePublisher
+                            .map { .failedToPlayToEndTime(String(describing: $0)) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.isPlaybackLikelyToKeepUpPublisher
+                            .map { .isPlaybackLikelyToKeepUp($0) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.playbackBufferStatePublisher
+                            .map { .playbackBufferState($0) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.playbackStalledPublisher
+                            .map { _ in .playbackStalled }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.timedMetadataGroupsPublisher
+                            .map { .timedMetadataGroups($0) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.newAccessLogEntryPublisher
+                            .flatMap { Publishers.Sequence(sequence: $0.events) }
+                            .map { .newAccessLogEvent($0) }
+                            .eraseToAnyPublisher(),
+
+                        currentItem.newErrorLogEntryPublisher
+                            .flatMap { Publishers.Sequence(sequence: $0.events) }
+                            .map { .newErrorLogEvent($0) }
+                            .eraseToAnyPublisher()
+                    ]
+                }()
+
+                let assetPublishers: [AnyPublisher<PlayerAction, Never>] = {
+                    guard let asset = player.currentItem?.asset else { return [] }
+
+                    return [
+                        asset.isPlayablePublisher
+                            .receive(on: DispatchQueue.main) // Required for @MainActor data-race detection.
+                            .map { .isPlayable($0) }
+                            .catch { _ in Empty(completeImmediately: true) }
+                            .eraseToAnyPublisher(),
+
+                        asset.durationPublisher
+                            .receive(on: DispatchQueue.main) // Required for @MainActor data-race detection.
+                            .map { .duration($0.seconds) }
+                            .catch { _ in Empty(completeImmediately: true) }
+                            .eraseToAnyPublisher()
+                    ]
+                }()
+
+                return Combine.Publishers
+                    .MergeMany(playerPublishers + playerItemPublishers + assetPublishers + {
+#if os(iOS)
+                        [
+                            AVAudioSession.sharedInstance().outputVolumePublisher
+                                .map { .outputVolume($0) }
+                                .eraseToAnyPublisher()
+                        ]
+#else
+                        []
+#endif
+                    }())
+                    .toAsyncStream()
+            }
+        )
+    }
+
+    @MainActor
+    func seek(to seekTime: @Sendable (_ current: TimeInterval) -> TimeInterval) async
+    {
+        guard let player = self.getPlayer(),
+              let currentItem = player.currentItem else { return }
+
+        let asset = currentItem.asset
+        let currentTime = player.currentTime().seconds
+
+        let seekTime = CMTime(seconds: seekTime(currentTime), preferredTimescale: asset.duration.timescale)
+
+        await withCheckedContinuation { continuation in
+            player.seek(to: seekTime) { _ in
+                continuation.resume()
+            }
+        }
+    }
+}
+
+// MARK: - EffectQueue
+
+struct PlayerSubscriptionEffectQueue: Newest1EffectQueueProtocol {}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootReducer.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootReducer.swift
@@ -1,0 +1,206 @@
+import AVFoundation
+import Combine
+import SwiftUI
+import AVFoundation_Combine
+import ActomatonStore
+import ActomatonDebugging
+
+// MARK: - Reducer
+
+func rootReducer() -> Reducer<RootAction, RootState, RootEnvironment>
+{
+    Reducer { action, state, environment in
+        switch action {
+        case .reloadRandom:
+            return Effect {
+                guard let url = environment.getRandomVideoURL() else { return nil }
+                return ._reload(url)
+            }
+
+        case let ._reload(url?):
+            let wasPaused = state.playerState.playingStatus == .paused
+
+            state.playerState.playingStatus = .paused
+
+            return Effect.nextAction(.pause)
+                + Effect { @MainActor in
+                    guard let player = environment.getPlayer() else { return nil }
+
+                    let reloadStartTime = CFAbsoluteTimeGetCurrent()
+
+                    let asset = AVAsset(url: url)
+                    let assetInitTime = CFAbsoluteTimeGetCurrent() - reloadStartTime
+
+                    // NOTE: `AVPlayerItem` will require `Sendable` in order to instantiate in background.
+                    let playerItem = AVPlayerItem(asset: asset)
+                    let playerItemInitTime = CFAbsoluteTimeGetCurrent() - reloadStartTime
+
+                    player.replaceCurrentItem(with: playerItem)
+                    let playerItemReplacedTime = CFAbsoluteTimeGetCurrent() - reloadStartTime
+
+                    return ._subscribePlayerAfterReload(
+                        assetInitTime: assetInitTime,
+                        playerItemInitTime: playerItemInitTime,
+                        playerItemReplacedTime: playerItemReplacedTime,
+                        wasPaused: wasPaused
+                    )
+                }
+
+        case ._reload(.none):
+            state.playerState.playingStatus = .paused
+
+            // Cancellation of subscription using `PlayerSubscriptionEffectQueue`.
+            return Effect.fireAndForget(queue: PlayerSubscriptionEffectQueue()) {}
+
+        case let ._subscribePlayerAfterReload(assetInitTime, playerItemInitTime, playerItemReplacedTime, wasPaused):
+            state.playerState.assetInitTime = assetInitTime
+            state.playerState.playerItemInitTime = playerItemInitTime
+            state.playerState.playerItemReplacedTime = playerItemReplacedTime
+            state.playerState.duration = .nan
+
+            return (!wasPaused ? Effect.nextAction(.play) : .empty)
+                + environment.playerSubscriptionEffect.map { ._playerAction($0) }
+
+        case let ._playerAction(.periodicTime(time)):
+            if !state.isSeeking {
+                state.playerState.currentTime = time.seconds
+            }
+
+        case let ._playerAction(.playingStatus(playingStatus)):
+            state.playerState.playingStatus = playingStatus
+
+        case let ._playerAction(.playerRate(playerRate)):
+            state.playerState.playerRate = playerRate
+
+        case let ._playerAction(.outputVolume(outputVolume)):
+            state.playerState.outputVolume = outputVolume
+
+        case let ._playerAction(.playerItemStatus(playerItemStatus)):
+            state.playerState.playerItemStatus = playerItemStatus
+
+        case let ._playerAction(.playerItemError(errorString)):
+            state.playerState.errorString = errorString
+
+        case let ._playerAction(.timebaseRate(timebaseRate)):
+            state.playerState.timebaseRate = timebaseRate
+
+        case ._playerAction(.timeJumped):
+            print("===> timeJumped")
+
+        case let ._playerAction(.loadedTimeRanges(loadedTimeRanges)):
+            state.playerState.loadedTimeRanges = loadedTimeRanges
+
+        case let ._playerAction(.seekableTimeRanges(seekableTimeRanges)):
+            state.playerState.seekableTimeRanges = seekableTimeRanges
+
+        case ._playerAction(.didPlayEndToTime):
+            print("===> didPlayEndToTime")
+
+        case let ._playerAction(.failedToPlayToEndTime(errorString)):
+            state.playerState.errorString = errorString
+
+        case let ._playerAction(.isPlaybackLikelyToKeepUp(isPlaybackLikelyToKeepUp)):
+            state.playerState.isPlaybackLikelyToKeepUp = isPlaybackLikelyToKeepUp
+
+        case let ._playerAction(.playbackBufferState(playbackBufferState)):
+            state.playerState.playbackBufferState = playbackBufferState
+
+        case ._playerAction(.playbackStalled):
+            print("===> playbackStalled")
+
+        case let ._playerAction(.timedMetadataGroups(timedMetadataGroups)):
+            state.playerState.timedMetadataGroups = timedMetadataGroups
+
+        case let ._playerAction(.newAccessLogEvent(newAccessLogEvent)):
+            state.playerState.newAccessLogEvent = prettify(newAccessLogEvent.descriptionDictionary).unescaped
+
+        case let ._playerAction(.newErrorLogEvent(newErrorLogEvent)):
+            state.playerState.newErrorLogEvent = prettify(newErrorLogEvent.descriptionDictionary).unescaped
+
+        case let ._playerAction(.isPlayable(isPlayable)):
+            state.playerState.isPlayable = isPlayable
+
+        case let ._playerAction(.duration(duration)):
+            state.playerState.duration = duration
+
+        case let .updateSliderValue(sliderValue):
+            state.sliderValue = sliderValue
+
+        case .didFinishSliderSeeking:
+            let wasPaused = state.playerState.playingStatus == .paused
+
+            let seekEffect: Effect<RootAction> = state.seekingTime.map { seekingTime in
+                Effect {
+                    await environment.seek(to: { _ in seekingTime })
+
+                    return RootAction._didFinishPlayerSeeking(
+                        seekingTime: seekingTime,
+                        wasPaused: wasPaused
+                    )
+                }
+            } ?? .empty
+
+            return Effect.nextAction(.pause)
+                + seekEffect
+
+        case let ._didFinishPlayerSeeking(seekingTime, wasPaused):
+            state.seekingTime = nil
+            state.playerState.currentTime = seekingTime
+
+            if !wasPaused {
+                return Effect.nextAction(.play)
+            }
+            else {
+                return Effect.empty
+            }
+
+        case .play:
+            if state.playerState.playingStatus == .paused {
+                return Effect.fireAndForget { @MainActor in
+                    guard let player = environment.getPlayer() else { return }
+                    player.play()
+                }
+            }
+
+        case .pause:
+            if state.playerState.playingStatus == .playing {
+                return Effect.fireAndForget { @MainActor in
+                    guard let player = environment.getPlayer() else { return }
+                    player.pause()
+                }
+            }
+
+        case let .advance(seconds):
+            return Effect.fireAndForget {
+                await environment.seek(to: { $0 + seconds })
+            }
+
+        case let .showDialog(label, value):
+            state.dialogText = "[\(label)]\n\n\(value.unescaped)"
+
+        case .closeDialog:
+            state.dialogText = nil
+        }
+
+        return .empty
+    }
+}
+
+// MARK: - Priavte
+
+private func prettify(_ any: Any) -> String
+{
+    let options: JSONSerialization.WritingOptions = [
+        .prettyPrinted,
+        .sortedKeys,
+        .withoutEscapingSlashes
+    ]
+
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: any, options: options),
+          let string = String(data: jsonData, encoding: .utf8)
+    else {
+        return "(failed prettify)"
+    }
+
+    return string
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootState.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootState.swift
@@ -1,0 +1,34 @@
+import AVFoundation
+import Combine
+import SwiftUI
+import AVFoundation_Combine
+
+struct RootState: Equatable, Sendable
+{
+    var playerState: PlayerState = .init()
+    var dialogText: String?
+    var seekingTime: TimeInterval?
+
+    var sliderValue: Float
+    {
+        get { Float((seekingTime ?? playerState.currentTime) / playerState.duration) }
+        set {
+            seekingTime = TimeInterval(newValue) * playerState.duration
+        }
+    }
+
+    var isSeeking: Bool
+    {
+        seekingTime != nil
+    }
+
+    var isSliderEnabled: Bool
+    {
+        playerState.playerItemStatus == .readyToPlay
+    }
+
+    var mirroredChildren: [(label: String, value: String)]
+    {
+        playerState.mirroredChildren
+    }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootView.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootView.swift
@@ -1,0 +1,181 @@
+import AVFoundation
+import AVKit
+import SwiftUI
+import ActomatonStore
+
+@MainActor
+struct RootView: View
+{
+    private let store: Store<RootAction, RootState, RootEnvironment>.Proxy
+
+    @SwiftUI.State
+    private var isInitialOnAppear: Bool = true
+
+    init(store: Store<RootAction, RootState, RootEnvironment>.Proxy)
+    {
+        self.store = store
+    }
+
+    var body: some View
+    {
+        ZStack {
+            main()
+
+            if let text = store.state.dialogText {
+                dialog(text: text)
+            }
+        }
+    }
+
+    private func main() -> some View
+    {
+        VStack(spacing: 24) {
+            ScrollView {
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+                    ForEach(store.state.mirroredChildren, id: \.label, content: { label, value in
+                        Group {
+                            Text("\(label)").bold()
+                            valueText(value).truncationMode(.head)
+                        }
+                        .onTapGesture {
+                            store.send(.showDialog(label: label, value: value))
+                        }
+                    })
+                        .lineLimit(1)
+                        .font(.callout)
+                }
+                .padding()
+            }
+            .border(Color.black)
+
+            HStack(spacing: 16) {
+                VStack(spacing: 16) {
+                    controlButtons()
+
+                    Button(action: { store.send(.reloadRandom) }, label: {
+                        Text("Reload")
+                    })
+                        .font(.body)
+
+                    Slider(
+                        value: store.sliderValue.stateBinding(onChange: RootAction.updateSliderValue),
+                        in: 0 ... 1,
+                        onEditingChanged: { isStarted in
+                            if !isStarted {
+                                store.send(.didFinishSliderSeeking)
+                            }
+                        }
+                    )
+                        .opacity(store.state.isSliderEnabled ? 1 : 0.5)
+                        .disabled(!store.state.isSliderEnabled)
+                }
+
+                AVKit.VideoPlayer(player: store.environment.getPlayer())
+                    .frame(maxWidth: 150, maxHeight: 150)
+            }
+        }
+        .font(.title)
+        .onAppear {
+            guard isInitialOnAppear else { return }
+            self.isInitialOnAppear = false
+
+            store.send(.reloadRandom)
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private func valueText(_ value: String) -> some View
+    {
+        let hasOneOfPrefix: (_ prefixes: String...) -> Bool = {
+            $0.first(where: { value.hasPrefix($0) }) != nil
+        }
+
+        if hasOneOfPrefix("paused", "unknown", "waitingToPlay") {
+            Text("\(value)").foregroundColor(.red)
+        } else if hasOneOfPrefix("readyToPlay", "playing") {
+            Text("\(value)").foregroundColor(.green)
+        } else {
+            Text("\(value)")
+        }
+    }
+
+    private func controlButtons() -> some View
+    {
+        HStack(spacing: 16) {
+            Button(action: { store.send(.advance(seconds: -10)) }, label: {
+                Image(systemName: "gobackward.10")
+            })
+            playOrPauseButton()
+            Button(action: { store.send(.advance(seconds: 10)) }, label: {
+                Image(systemName: "goforward.10")
+            })
+        }
+    }
+
+    @ViewBuilder
+    private func playOrPauseButton() -> some View
+    {
+        switch store.state.playerState.playingStatus {
+        case .playing, .waitingToPlay, .unknown:
+            Button(action: { store.send(.pause) }, label: {
+                Image(systemName: "pause.circle")
+            })
+        case .paused:
+            Button(action: { store.send(.play) }, label: {
+                Image(systemName: "play.circle")
+            })
+        }
+    }
+
+    // MARK: - Dialog
+
+    private func dialog(text: String) -> some View
+    {
+        GeometryReader { g in
+            ScrollView {
+                Text(text)
+                    .padding()
+            }
+            .clipped()
+            .background(Color.white)
+            .border(Color.black, width: 3)
+            .frame(maxHeight: g.size.height)
+            .padding()
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(
+                minWidth: 0,
+                maxWidth: .infinity,
+                minHeight: 0,
+                maxHeight: .infinity,
+                alignment: .center
+            )
+            // NOTE: Simulator needs this to close.
+            .onTapGesture {
+                store.send(.closeDialog)
+            }
+            .background(
+                Color(white: 1, opacity: 0.75)
+                    .ignoresSafeArea(.all, edges: .all)
+            )
+        }
+        // NOTE: Only works for device.
+        .onTapGesture {
+            store.send(.closeDialog)
+        }
+    }
+}
+
+struct RootView_Previews: PreviewProvider
+{
+    static var previews: some View
+    {
+        RootView(
+            store: .init(
+                state: .constant(.init()),
+                environment: .init(getPlayer: { nil }, getRandomVideoURL: { nil }),
+                send: { _ in }
+            )
+        )
+    }
+}

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/UncheckedSendable.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/UncheckedSendable.swift
@@ -1,0 +1,9 @@
+import Foundation
+import AVFoundation
+
+extension URL: @unchecked Sendable {}
+extension Notification: @unchecked Sendable {}
+extension AVAsset: @unchecked Sendable {}
+extension AVTimedMetadataGroup: @unchecked Sendable {}
+extension AVPlayerItemAccessLogEvent: @unchecked Sendable {}
+extension AVPlayerItemErrorLogEvent: @unchecked Sendable {}

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ build-Favorite-Sync:
 	cd Examples/Favorite-Sync/ && \
 	xcodebuild build -scheme Actomaton-Favorite-Sync $(DESTINATION) | xcpretty
 
+.PHONY: build-VideoPlayer
+build-VideoPlayer:
+	cd Examples/VideoPlayer/ && \
+	xcodebuild build -scheme Actomaton-VideoPlayer $(DESTINATION) | xcpretty
+
 # e.g.
 # make universal-link
 # make universal-link path=counter?count=3


### PR DESCRIPTION
Related:
- #36 

## Overview

This PR adds `Actomaton-VideoPlayer` example to demonstrate how to use `AVPlayer` as external dependency.

This demo doesn't use `VideoPlayer` module introduced in #36 .

Unlike simple module in #36, this demo presents more thorough AVPlayer state management by adding many possible data bindings via [AVFoundation-Combine](https://github.com/inamiy/AVFoundation-Combine), which is also useful as `AVPlayer` debugging demo too.

## Screencast

https://user-images.githubusercontent.com/138476/160113923-0956c0cf-e98e-4bfb-b8b6-499426e9eb68.mp4

 