### PR TITLE
Use `#if swift(>=5.6) && swift(<5.7)` for `-Xfrontend -requirement-machine=off`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,7 @@ let package = Package(
                 // https://github.com/inamiy/Actomaton-Gallery/pull/33
                 // https://twitter.com/slava_pestov/status/1503903893389983745
                 .unsafeFlags({
-#if swift(>=5.6)
+#if swift(>=5.6) && swift(<5.7)
                     [
                         "-Xfrontend", "-requirement-machine=off",
                     ]


### PR DESCRIPTION
Successor of:
- https://github.com/Actomaton/Actomaton-Gallery/pull/34

This PR adds `swift(<5.7)` to disable `-Xfrontend -requirement-machine=off` for Xcode 14 (Beta 1) Swift 5.7.