### PR TITLE
Improve Swift Concurrency using `unsafeFlags`

### DIFF
--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Extensions/AVFoundation+Extensions.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Extensions/AVFoundation+Extensions.swift
@@ -54,7 +54,7 @@ extension AVPlayerItemErrorLogEvent
 
 extension AVPlayerItemAccessLog
 {
-    open var extendedLogString: String?
+    public var extendedLogString: String?
     {
         guard let data = extendedLogData(),
               let string = String(data: data, encoding: .init(rawValue: extendedLogDataStringEncoding))
@@ -66,7 +66,7 @@ extension AVPlayerItemAccessLog
 
 extension AVPlayerItemErrorLog
 {
-    open var extendedLogString: String?
+    public var extendedLogString: String?
     {
         guard let data = extendedLogData(),
               let string = String(data: data, encoding: .init(rawValue: extendedLogDataStringEncoding))

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.5
 
+import Foundation
 import PackageDescription
 
 let package = Package(
@@ -285,3 +286,17 @@ let package = Package(
             ])
     ]
 )
+
+// Comment-Out:
+// Concurrency warning around Xcode Preview is shown too many (possibly due to compiler bug),
+// so will turn off by default.
+// https://github.com/apple/swift/issues/61300
+//
+//    for target in package.targets {
+//        target.swiftSettings = [
+//            .unsafeFlags([
+//                "-Xfrontend", "-warn-concurrency",
+//                "-Xfrontend", "-enable-actor-data-race-checks",
+//            ])
+//        ]
+//    }

--- a/Sources/CommonEffects/CommonEffects.swift
+++ b/Sources/CommonEffects/CommonEffects.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ActomatonUI
 
-public struct CommonEffects
+public struct CommonEffects: Sendable
 {
     private let urlSession: URLSession
     private let _timer: @Sendable (TimeInterval) -> AsyncStream<Date>

--- a/Sources/CommonUI/TapView.swift
+++ b/Sources/CommonUI/TapView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// as of Xcode 11.1 SwiftUI.
 /// 
 /// - SeeAlso: https://stackoverflow.com/a/56518293/666371
+@MainActor
 public struct TapView: UIViewRepresentable
 {
     private let didTap: (CGPoint) -> Void
@@ -36,6 +37,7 @@ public struct TapView: UIViewRepresentable
     {
     }
 
+    @MainActor
     public final class Coordinator: NSObject
     {
         let didTap: ((CGPoint) -> Void)

--- a/Sources/ImageLoader/ImageLoader.swift
+++ b/Sources/ImageLoader/ImageLoader.swift
@@ -23,11 +23,11 @@ public struct State: Equatable, Sendable
 
 // MARK: - Environment
 
-public struct Environment
+public struct Environment: Sendable
 {
-    let fetchImage: (URL) async -> UIImage?
+    let fetchImage: @Sendable (URL) async -> UIImage?
 
-    public init(fetchImage: @escaping (URL) async -> UIImage?)
+    public init(fetchImage: @escaping @Sendable (URL) async -> UIImage?)
     {
         self.fetchImage = fetchImage
     }

--- a/Sources/LiveEnvironments/Environment.live.swift
+++ b/Sources/LiveEnvironments/Environment.live.swift
@@ -158,6 +158,7 @@ extension VideoPlayer.Environment: LiveEnvironment
     public init(commonEffects: CommonEffects)
     {
         /// Effectful references.
+        @MainActor
         class Refs {
             var player: AVPlayer?
         }

--- a/Sources/LiveEnvironments/LiveEnvironment.swift
+++ b/Sources/LiveEnvironments/LiveEnvironment.swift
@@ -3,11 +3,13 @@ import CommonEffects
 /// Protocol for derived environment from `CommonEffects` that can make ``live`` enviornment.
 public protocol LiveEnvironment
 {
+    @MainActor
     init(commonEffects: CommonEffects)
 }
 
 extension LiveEnvironment
 {
+    @MainActor
     public static var live: Self
     {
         .init(commonEffects: .live)

--- a/Sources/Physics/ExampleList/Example.swift
+++ b/Sources/Physics/ExampleList/Example.swift
@@ -80,27 +80,34 @@ protocol ObjectWorldExample: Example
 
     /// Custom logic called on every "tick" to modify `objects`, mainly to calculate surrounding forces.
     /// - Note: `object`'s `velocity` and `position` will be automatically calculated afterwards.
+    @Sendable
     func step(objects: inout [Obj], boardSize: CGSize)
 
     /// Custom logic called on "dragging empty area" to modify `objects`.
+    @Sendable
     func draggingEmptyArea(_ objects: inout [Obj], point: CGPoint)
 
     /// Custom logic called on "drag-end empty area" to modify `objects`.
+    @Sendable
     func dragEndEmptyArea(_ objects: inout [Obj])
 
     /// Creating a new object on tap.
+    @Sendable
     func exampleTapToMakeObject(point: CGPoint) -> Obj?
 }
 
 extension ObjectWorldExample where Obj == CircleObject
 {
     /// Default impl.
+    @Sendable
     func draggingEmptyArea(_ objects: inout [Obj], point: CGPoint) {}
 
     /// Default impl.
+    @Sendable
     func dragEndEmptyArea(_ objects: inout [Obj]) {}
 
     /// Default impl.
+    @Sendable
     func exampleTapToMakeObject(point: CGPoint) -> Obj?
     {
         CircleObject(position: Vector2(point))
@@ -111,8 +118,8 @@ extension ObjectWorldExample where Obj == CircleObject
         World
             .reducer(
                 tick: World.tickForObjects(self.step),
-                tap: { objects, point in
-                    if let object = exampleTapToMakeObject(point: point) {
+                tap: { [exampleTapToMakeObject] objects, point in
+                    if let object = exampleTapToMakeObject(point) {
                         objects.append(object)
                     }
                 },
@@ -139,8 +146,8 @@ extension ObjectWorldExample where Obj == Object
         World
             .reducer(
                 tick: World.tickForObjects(self.step),
-                tap: { objects, point in
-                    if let object = exampleTapToMakeObject(point: point) {
+                tap: { [exampleTapToMakeObject] objects, point in
+                    if let object = exampleTapToMakeObject(point) {
                         objects.append(object)
                     }
                 },
@@ -158,21 +165,26 @@ protocol BobWorldExample: Example
 {
     /// Custom logic called on every "tick" to modify `objects`, mainly to calculate angular acceleration.
     /// - Parameter Δt: Simulated delta time per tick.
+    @Sendable
     func step(objects: inout [Bob], boardSize: CGSize, Δt: Scalar)
 
     /// Custom logic called on "dragging empty area" to modify `objects`.
+    @Sendable
     func draggingEmptyArea(_ objects: inout [Bob], point: CGPoint)
 
     /// Custom logic called on "drag-end empty area" to modify `objects`.
+    @Sendable
     func dragEndEmptyArea(_ objects: inout [Bob])
 }
 
 extension BobWorldExample
 {
     /// Default impl.
+    @Sendable
     func draggingEmptyArea(_ objects: inout [Bob], point: CGPoint) {}
 
     /// Default impl.
+    @Sendable
     func dragEndEmptyArea(_ objects: inout [Bob]) {}
 
     var reducer: Reducer<World.Action, World.State<Bob>, World.Environment>

--- a/Sources/Physics/Models/Bob/World+Bob.swift
+++ b/Sources/Physics/Models/Bob/World+Bob.swift
@@ -6,8 +6,9 @@ extension World
 {
     /// Resets `bobs` angular accelerations, and `run` custom logic (no calculation of `angleVelocity` & `angle`).
     /// - Parameter Δt: Simulated delta time per tick.
-    static func tickForBobs(_ run: @escaping (inout [Bob], _ boardSize: CGSize, _ Δt: Scalar) -> Void)
-        -> (inout [Bob], _ boardSize: CGSize, _ Δt: Scalar) -> Void
+    @Sendable
+    static func tickForBobs(_ run: @escaping @Sendable (inout [Bob], _ boardSize: CGSize, _ Δt: Scalar) -> Void)
+        -> @Sendable (inout [Bob], _ boardSize: CGSize, _ Δt: Scalar) -> Void
     {
         { bobs, boardSize, Δt in
             var bobCount = bobs.count

--- a/Sources/Physics/Models/Object/World+Object.swift
+++ b/Sources/Physics/Models/Object/World+Object.swift
@@ -5,9 +5,10 @@ import VectorMath
 extension World
 {
     /// Resets `objects` forces, `run` custom logic, and calculates `velocity` & `position`.
-    /// - Parameter Δt: Simulated delta time per tick. 
-    static func tickForObjects<Obj>(_ run: @escaping (inout [Obj], _ boardSize: CGSize) -> Void)
-        -> (inout [Obj], _ boardSize: CGSize, _ Δt: Scalar) -> Void
+    /// - Parameter Δt: Simulated delta time per tick.
+    @Sendable
+    static func tickForObjects<Obj>(_ run: @escaping @Sendable (inout [Obj], _ boardSize: CGSize) -> Void)
+        -> @Sendable (inout [Obj], _ boardSize: CGSize, _ Δt: Scalar) -> Void
         where Obj: _ObjectLike
     {
         { objects, boardSize, Δt in

--- a/Sources/Physics/World/World.swift
+++ b/Sources/Physics/World/World.swift
@@ -107,11 +107,11 @@ public enum World
     ///   - draggingEmptyArea: Custom logic called on "dragging empty area" to modify `objects`.
     ///   - dragEndEmptyArea: Custom logic called on "drag-end empty area" to modify `objects`.
     public static func reducer<Obj>(
-        tick: @escaping (inout [Obj], CGSize, _ Δt: Scalar) -> Void,
-        tap: @escaping (inout [Obj], CGPoint) -> Void = { _, _ in },
-        draggingObj: @escaping (inout Obj, CGPoint) -> Void = { _, _ in },
-        draggingEmptyArea: @escaping (inout [Obj], CGPoint) -> Void = { _, _ in },
-        dragEndEmptyArea: @escaping (inout [Obj]) -> Void = { _ in }
+        tick: @escaping @Sendable (inout [Obj], CGSize, _ Δt: Scalar) -> Void,
+        tap: @escaping @Sendable (inout [Obj], CGPoint) -> Void = { _, _ in },
+        draggingObj: @escaping @Sendable (inout Obj, CGPoint) -> Void = { _, _ in },
+        draggingEmptyArea: @escaping @Sendable (inout [Obj], CGPoint) -> Void = { _, _ in },
+        dragEndEmptyArea: @escaping @Sendable (inout [Obj]) -> Void = { _ in }
     ) -> Reducer<World.Action, World.State<Obj>, Environment>
         where Obj: ObjectLike
     {
@@ -132,11 +132,11 @@ public enum World
     }
 
     private static func canvasReducer<Obj>(
-        tick: @escaping (inout [Obj], CGSize, _ Δt: Scalar) -> Void,
-        tap: @escaping (inout [Obj], CGPoint) -> Void = { _, _ in },
-        draggingObj: @escaping (inout Obj, CGPoint) -> Void = { _, _ in },
-        draggingEmptyArea: @escaping (inout [Obj], CGPoint) -> Void = { _, _ in },
-        dragEndEmptyArea: @escaping (inout [Obj]) -> Void = { _ in }
+        tick: @escaping @Sendable (inout [Obj], CGSize, _ Δt: Scalar) -> Void,
+        tap: @escaping @Sendable (inout [Obj], CGPoint) -> Void = { _, _ in },
+        draggingObj: @escaping @Sendable (inout Obj, CGPoint) -> Void = { _, _ in },
+        draggingEmptyArea: @escaping @Sendable (inout [Obj], CGPoint) -> Void = { _, _ in },
+        dragEndEmptyArea: @escaping @Sendable (inout [Obj]) -> Void = { _ in }
     ) -> Reducer<Action, CanvasState<Obj>, Environment>
         where Obj: ObjectLike
     {

--- a/Sources/Tab/Tab.swift
+++ b/Sources/Tab/Tab.swift
@@ -30,7 +30,7 @@ public struct State<InnerState, TabID>: Equatable, Sendable
 // MARK: - Reducer
 
 public func reducer<InnerAction, InnerState, Environment, TabID>(
-    innerReducers: @escaping (TabID) -> Reducer<InnerAction, InnerState, Environment>
+    innerReducers: @escaping @Sendable (TabID) -> Reducer<InnerAction, InnerState, Environment>
 ) -> Reducer<Action<InnerAction, InnerState, TabID>, State<InnerState, TabID>, Environment>
     where TabID: Hashable
 {
@@ -55,7 +55,7 @@ private func changeTabReducer<InnerAction, InnerState, Environment, TabID>()
 }
 
 private func tabChildrenReducer<InnerAction, InnerState, Environment, TabID>(
-    innerReducers: @escaping (TabID) -> Reducer<InnerAction, InnerState, Environment>
+    innerReducers: @escaping @Sendable (TabID) -> Reducer<InnerAction, InnerState, Environment>
 ) -> Reducer<Action<InnerAction, InnerState, TabID>, State<InnerState, TabID>, Environment>
     where TabID: Hashable
 {

--- a/Sources/UIKit/RootUIKit/Root.swift
+++ b/Sources/UIKit/RootUIKit/Root.swift
@@ -139,7 +139,7 @@ private var debugTabInsertRemoveReducer: Reducer<Action, State, Environment>
     Reducer { action, state, environment in
         switch action {
         case let .insertRandomTab(index):
-            return Effect {
+            return Effect { @MainActor in
                 // Random alphabet "A" ... "Z".
                 let char = (65 ... 90).map { String(UnicodeScalar($0)) }.randomElement()!
 

--- a/Sources/UIKit/TabUIKit/TabItem.swift
+++ b/Sources/UIKit/TabUIKit/TabItem.swift
@@ -33,6 +33,7 @@ public struct TabItem<ID>: Equatable, Sendable
 extension TabItem
 {
     /// Initializes with `image`.
+    @MainActor
     public init(
         id: ID,
         title: String,
@@ -47,6 +48,7 @@ extension TabItem
     }
 
     /// Initializes with `examples`.
+    @MainActor
     public init(
         id: ID,
         title: String,
@@ -63,6 +65,7 @@ extension TabItem
     }
 
     /// Initializes with `Store` and `SwiftUI.View`.
+    @MainActor
     public init<Action, State, V: View>(
         id: ID,
         title: String,
@@ -80,6 +83,7 @@ extension TabItem
     }
 
     /// Initializes with `SwiftUI.View`.
+    @MainActor
     public init<V: View>(
         id: ID,
         title: String,

--- a/Sources/UserSessionNavigation/Login/LoginView.swift
+++ b/Sources/UserSessionNavigation/Login/LoginView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import ActomatonUI
 import Utilities
 
+@MainActor
 public struct LoginView: View
 {
     private let onAction: (Action) -> Void

--- a/Sources/VideoCapture/Effects.swift
+++ b/Sources/VideoCapture/Effects.swift
@@ -5,6 +5,8 @@ import Combine
 import ActomatonUI
 import OrientationKit
 
+// FIXME: This entire effectful code needs to be refactored to avoid using global variables and make Sendable-friendly.
+
 // MARK: -  Global states
 
 internal enum Global


### PR DESCRIPTION
This PR adds following `unsafeFlags` to improve Swift Concurrency handling.

```swift
for target in package.targets {
    target.swiftSettings = [
        .unsafeFlags([
            "-Xfrontend", "-warn-concurrency",
            "-Xfrontend", "-enable-actor-data-race-checks",
        ])
    ]
}
```