### PR TITLE
Update Actomaton to 0.8.0

### DIFF
--- a/Examples/Actomaton-Basic.swiftpm/CounterAppView.swift
+++ b/Examples/Actomaton-Basic.swiftpm/CounterAppView.swift
@@ -1,24 +1,22 @@
 import SwiftUI
-import ActomatonStore
+import ActomatonUI
 
 @MainActor
 struct CounterAppView: View
 {
-    @StateObject
-    private var store: Store<Action, State>
+    private let store: Store<Action, State, Void>
 
     init()
     {
-        let store = Store<Action, State>(
+        self.store = Store<Action, State, Void>(
             state: State(),
             reducer: reducer()
         )
-        self._store = StateObject(wrappedValue: store)
     }
 
     var body: some View
     {
         // IMPORTANT: Pass `Store.Proxy` to children.
-        CounterView(store: self.store.proxy)
+        CounterView(store: self.store)
     }
 }

--- a/Examples/Actomaton-Basic.swiftpm/CounterView.swift
+++ b/Examples/Actomaton-Basic.swiftpm/CounterView.swift
@@ -1,32 +1,34 @@
 import SwiftUI
-import ActomatonStore
+import ActomatonUI
 
 @MainActor
 struct CounterView: View
 {
-    private let store: Store<Action, State>.Proxy
+    private let store: Store<Action, State, Void>
 
-    init(store: Store<Action, State>.Proxy)
+    init(store: Store<Action, State, Void>)
     {
         self.store = store
     }
 
     var body: some View
     {
-        HStack(spacing: 20) {
+        WithViewStore(self.store) { viewStore in
             HStack(spacing: 20) {
-                Button(action: { self.store.send(.decrement) }) {
-                    Image(systemName: "minus.circle")
-                }
+                HStack(spacing: 20) {
+                    Button(action: { self.store.send(.decrement) }) {
+                        Image(systemName: "minus.circle")
+                    }
 
-                Text("\(store.state.count)")
-                    .frame(width: 100)
+                    Text("\(viewStore.state.count)")
+                        .frame(width: 100)
 
-                Button(action: { self.store.send(.increment) }) {
-                    Image(systemName: "plus.circle")
+                    Button(action: { self.store.send(.increment) }) {
+                        Image(systemName: "plus.circle")
+                    }
                 }
+                .font(.system(size: 64))
             }
-            .font(.system(size: 64))
         }
     }
 }
@@ -36,11 +38,8 @@ struct CounterView_Previews: PreviewProvider
     static var previews: some View
     {
         CounterView(
-            store: .init(
-                state: .constant(.init()),
-                send: { _ in }
-            )
+            store: Store(state: State(count: 123), reducer: reducer())
         )
-            .previewLayout(.sizeThatFits)
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/Examples/Actomaton-Basic.swiftpm/Package.resolved
+++ b/Examples/Actomaton-Basic.swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/inamiy/Actomaton",
         "state": {
           "branch": null,
-          "revision": "45d04852eaf32d382b7c907767f0ad3fc11065c8",
-          "version": "0.3.1"
+          "revision": "e51e5ea17f3fb31f4d98eaab1d044f33d4c02386",
+          "version": "0.8.0"
         }
       },
       {

--- a/Examples/Actomaton-Basic.swiftpm/Package.swift
+++ b/Examples/Actomaton-Basic.swiftpm/Package.swift
@@ -35,13 +35,13 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/inamiy/Actomaton", from: "0.3.1")
+        .package(url: "https://github.com/inamiy/Actomaton", from: "0.8.0")
     ],
     targets: [
         .executableTarget(
             name: "AppModule",
             dependencies: [
-                .productItem(name: "ActomatonStore", package: "Actomaton", condition: nil)
+                .productItem(name: "ActomatonUI", package: "Actomaton", condition: nil)
             ],
             path: ".",
             swiftSettings: [.unsafeFlags(["-warn-concurrency"], .when(configuration: .debug))]

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,88 +1,86 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Actomaton",
-        "repositoryURL": "https://github.com/inamiy/Actomaton",
-        "state": {
-          "branch": "main",
-          "revision": "18725b4cbb2d9ce8ed670128d95ea3cb4b44426f",
-          "version": null
-        }
-      },
-      {
-        "package": "AVFoundation-Combine",
-        "repositoryURL": "https://github.com/inamiy/AVFoundation-Combine",
-        "state": {
-          "branch": "main",
-          "revision": "637ba786561616297554365d12402414d5024335",
-          "version": null
-        }
-      },
-      {
-        "package": "CombineCocoa",
-        "repositoryURL": "https://github.com/CombineCommunity/CombineCocoa",
-        "state": {
-          "branch": null,
-          "revision": "4e262c2f9fb1cee1cb3be5717f7e6b55eb823971",
-          "version": "0.4.0"
-        }
-      },
-      {
-        "package": "OrientationKit",
-        "repositoryURL": "https://github.com/inamiy/OrientationKit",
-        "state": {
-          "branch": null,
-          "revision": "491927e9cc835c0fcc7eac349c0245024f5d8579",
-          "version": "0.1.0"
-        }
-      },
-      {
-        "package": "swift-case-paths",
-        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
-        "state": {
-          "branch": null,
-          "revision": "a09839348486db8866f85a727b8550be1d671c50",
-          "version": "0.9.1"
-        }
-      },
-      {
-        "package": "swift-custom-dump",
-        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
-        "state": {
-          "branch": null,
-          "revision": "21ec1d717c07cea5a026979cb0471dd95c7087e7",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "SwiftUI-PhotoPicker",
-        "repositoryURL": "https://github.com/inamiy/SwiftUI-PhotoPicker",
-        "state": {
-          "branch": "main",
-          "revision": "7fa6cc560e9c48dca41de152686ebd572eb88edf",
-          "version": null
-        }
-      },
-      {
-        "package": "VectorMath",
-        "repositoryURL": "https://github.com/nicklockwood/VectorMath",
-        "state": {
-          "branch": null,
-          "revision": "2de2585f455dc8e15d642ca51b29b1917e68fd1e",
-          "version": "0.4.1"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "ef8e14e7ce1c0c304c644c6ba365d06c468ded6b",
-          "version": "0.3.3"
-        }
+  "pins" : [
+    {
+      "identity" : "actomaton",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/Actomaton",
+      "state" : {
+        "revision" : "e51e5ea17f3fb31f4d98eaab1d044f33d4c02386",
+        "version" : "0.8.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "avfoundation-combine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/AVFoundation-Combine",
+      "state" : {
+        "branch" : "main",
+        "revision" : "637ba786561616297554365d12402414d5024335"
+      }
+    },
+    {
+      "identity" : "combinecocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CombineCommunity/CombineCocoa",
+      "state" : {
+        "revision" : "4e262c2f9fb1cee1cb3be5717f7e6b55eb823971",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "orientationkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/OrientationKit",
+      "state" : {
+        "revision" : "491927e9cc835c0fcc7eac349c0245024f5d8579",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "a09839348486db8866f85a727b8550be1d671c50",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "21ec1d717c07cea5a026979cb0471dd95c7087e7",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swiftui-photopicker",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/SwiftUI-PhotoPicker",
+      "state" : {
+        "branch" : "main",
+        "revision" : "7fa6cc560e9c48dca41de152686ebd572eb88edf"
+      }
+    },
+    {
+      "identity" : "vectormath",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/VectorMath",
+      "state" : {
+        "revision" : "2de2585f455dc8e15d642ca51b29b1917e68fd1e",
+        "version" : "0.4.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "ef8e14e7ce1c0c304c644c6ba365d06c468ded6b",
+        "version" : "0.3.3"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,88 +1,86 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Actomaton",
-        "repositoryURL": "https://github.com/inamiy/Actomaton",
-        "state": {
-          "branch": "main",
-          "revision": "6806a3d6bf075d89730996eea1ccf7215ccdd4ba",
-          "version": null
-        }
-      },
-      {
-        "package": "AVFoundation-Combine",
-        "repositoryURL": "https://github.com/inamiy/AVFoundation-Combine",
-        "state": {
-          "branch": "main",
-          "revision": "637ba786561616297554365d12402414d5024335",
-          "version": null
-        }
-      },
-      {
-        "package": "Inject",
-        "repositoryURL": "https://github.com/krzysztofzablocki/Inject",
-        "state": {
-          "branch": null,
-          "revision": "a45509eac083b42afd4b6fd00a93a2b53f99f3eb",
-          "version": "1.2.1"
-        }
-      },
-      {
-        "package": "OrientationKit",
-        "repositoryURL": "https://github.com/inamiy/OrientationKit",
-        "state": {
-          "branch": null,
-          "revision": "491927e9cc835c0fcc7eac349c0245024f5d8579",
-          "version": "0.1.0"
-        }
-      },
-      {
-        "package": "swift-case-paths",
-        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
-        "state": {
-          "branch": null,
-          "revision": "a09839348486db8866f85a727b8550be1d671c50",
-          "version": "0.9.1"
-        }
-      },
-      {
-        "package": "swift-custom-dump",
-        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
-        "state": {
-          "branch": null,
-          "revision": "21ec1d717c07cea5a026979cb0471dd95c7087e7",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "SwiftUI-PhotoPicker",
-        "repositoryURL": "https://github.com/inamiy/SwiftUI-PhotoPicker",
-        "state": {
-          "branch": "main",
-          "revision": "7fa6cc560e9c48dca41de152686ebd572eb88edf",
-          "version": null
-        }
-      },
-      {
-        "package": "VectorMath",
-        "repositoryURL": "https://github.com/nicklockwood/VectorMath",
-        "state": {
-          "branch": null,
-          "revision": "2de2585f455dc8e15d642ca51b29b1917e68fd1e",
-          "version": "0.4.1"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "38bc9242e4388b80bd23ddfdf3071428859e3260",
-          "version": "0.4.0"
-        }
+  "pins" : [
+    {
+      "identity" : "actomaton",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/Actomaton",
+      "state" : {
+        "revision" : "e51e5ea17f3fb31f4d98eaab1d044f33d4c02386",
+        "version" : "0.8.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "avfoundation-combine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/AVFoundation-Combine",
+      "state" : {
+        "branch" : "main",
+        "revision" : "637ba786561616297554365d12402414d5024335"
+      }
+    },
+    {
+      "identity" : "inject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzysztofzablocki/Inject",
+      "state" : {
+        "revision" : "a45509eac083b42afd4b6fd00a93a2b53f99f3eb",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "orientationkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/OrientationKit",
+      "state" : {
+        "revision" : "491927e9cc835c0fcc7eac349c0245024f5d8579",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "a09839348486db8866f85a727b8550be1d671c50",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "21ec1d717c07cea5a026979cb0471dd95c7087e7",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swiftui-photopicker",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/SwiftUI-PhotoPicker",
+      "state" : {
+        "branch" : "main",
+        "revision" : "7fa6cc560e9c48dca41de152686ebd572eb88edf"
+      }
+    },
+    {
+      "identity" : "vectormath",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/VectorMath",
+      "state" : {
+        "revision" : "2de2585f455dc8e15d642ca51b29b1917e68fd1e",
+        "version" : "0.4.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "38bc9242e4388b80bd23ddfdf3071428859e3260",
+        "version" : "0.4.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Examples/UIKit-Gallery/Actomaton-UIKit-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/UIKit-Gallery/Actomaton-UIKit-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,79 +1,77 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Actomaton",
-        "repositoryURL": "https://github.com/inamiy/Actomaton",
-        "state": {
-          "branch": "main",
-          "revision": "18725b4cbb2d9ce8ed670128d95ea3cb4b44426f",
-          "version": null
-        }
-      },
-      {
-        "package": "AVFoundation-Combine",
-        "repositoryURL": "https://github.com/inamiy/AVFoundation-Combine",
-        "state": {
-          "branch": "main",
-          "revision": "637ba786561616297554365d12402414d5024335",
-          "version": null
-        }
-      },
-      {
-        "package": "OrientationKit",
-        "repositoryURL": "https://github.com/inamiy/OrientationKit",
-        "state": {
-          "branch": null,
-          "revision": "491927e9cc835c0fcc7eac349c0245024f5d8579",
-          "version": "0.1.0"
-        }
-      },
-      {
-        "package": "swift-case-paths",
-        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
-        "state": {
-          "branch": null,
-          "revision": "a09839348486db8866f85a727b8550be1d671c50",
-          "version": "0.9.1"
-        }
-      },
-      {
-        "package": "swift-custom-dump",
-        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
-        "state": {
-          "branch": null,
-          "revision": "21ec1d717c07cea5a026979cb0471dd95c7087e7",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "SwiftUI-PhotoPicker",
-        "repositoryURL": "https://github.com/inamiy/SwiftUI-PhotoPicker",
-        "state": {
-          "branch": "main",
-          "revision": "7fa6cc560e9c48dca41de152686ebd572eb88edf",
-          "version": null
-        }
-      },
-      {
-        "package": "VectorMath",
-        "repositoryURL": "https://github.com/nicklockwood/VectorMath",
-        "state": {
-          "branch": null,
-          "revision": "2de2585f455dc8e15d642ca51b29b1917e68fd1e",
-          "version": "0.4.1"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "ef8e14e7ce1c0c304c644c6ba365d06c468ded6b",
-          "version": "0.3.3"
-        }
+  "pins" : [
+    {
+      "identity" : "actomaton",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/Actomaton",
+      "state" : {
+        "revision" : "e51e5ea17f3fb31f4d98eaab1d044f33d4c02386",
+        "version" : "0.8.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "avfoundation-combine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/AVFoundation-Combine",
+      "state" : {
+        "branch" : "main",
+        "revision" : "637ba786561616297554365d12402414d5024335"
+      }
+    },
+    {
+      "identity" : "orientationkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/OrientationKit",
+      "state" : {
+        "revision" : "491927e9cc835c0fcc7eac349c0245024f5d8579",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "a09839348486db8866f85a727b8550be1d671c50",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "21ec1d717c07cea5a026979cb0471dd95c7087e7",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swiftui-photopicker",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/SwiftUI-PhotoPicker",
+      "state" : {
+        "branch" : "main",
+        "revision" : "7fa6cc560e9c48dca41de152686ebd572eb88edf"
+      }
+    },
+    {
+      "identity" : "vectormath",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/VectorMath",
+      "state" : {
+        "revision" : "2de2585f455dc8e15d642ca51b29b1917e68fd1e",
+        "version" : "0.4.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "ef8e14e7ce1c0c304c644c6ba365d06c468ded6b",
+        "version" : "0.3.3"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,88 +1,86 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Actomaton",
-        "repositoryURL": "https://github.com/inamiy/Actomaton",
-        "state": {
-          "branch": "main",
-          "revision": "47a3b125a847a1b92cc1a37914a3e61d171cbea2",
-          "version": null
-        }
-      },
-      {
-        "package": "AVFoundation-Combine",
-        "repositoryURL": "https://github.com/inamiy/AVFoundation-Combine",
-        "state": {
-          "branch": "main",
-          "revision": "637ba786561616297554365d12402414d5024335",
-          "version": null
-        }
-      },
-      {
-        "package": "CombineCocoa",
-        "repositoryURL": "https://github.com/CombineCommunity/CombineCocoa",
-        "state": {
-          "branch": null,
-          "revision": "4e262c2f9fb1cee1cb3be5717f7e6b55eb823971",
-          "version": "0.4.0"
-        }
-      },
-      {
-        "package": "OrientationKit",
-        "repositoryURL": "https://github.com/inamiy/OrientationKit",
-        "state": {
-          "branch": null,
-          "revision": "491927e9cc835c0fcc7eac349c0245024f5d8579",
-          "version": "0.1.0"
-        }
-      },
-      {
-        "package": "swift-case-paths",
-        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
-        "state": {
-          "branch": null,
-          "revision": "a09839348486db8866f85a727b8550be1d671c50",
-          "version": "0.9.1"
-        }
-      },
-      {
-        "package": "swift-custom-dump",
-        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
-        "state": {
-          "branch": null,
-          "revision": "21ec1d717c07cea5a026979cb0471dd95c7087e7",
-          "version": "0.5.0"
-        }
-      },
-      {
-        "package": "SwiftUI-PhotoPicker",
-        "repositoryURL": "https://github.com/inamiy/SwiftUI-PhotoPicker",
-        "state": {
-          "branch": "main",
-          "revision": "7fa6cc560e9c48dca41de152686ebd572eb88edf",
-          "version": null
-        }
-      },
-      {
-        "package": "VectorMath",
-        "repositoryURL": "https://github.com/nicklockwood/VectorMath",
-        "state": {
-          "branch": null,
-          "revision": "2de2585f455dc8e15d642ca51b29b1917e68fd1e",
-          "version": "0.4.1"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "ef8e14e7ce1c0c304c644c6ba365d06c468ded6b",
-          "version": "0.3.3"
-        }
+  "pins" : [
+    {
+      "identity" : "actomaton",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/Actomaton",
+      "state" : {
+        "revision" : "e51e5ea17f3fb31f4d98eaab1d044f33d4c02386",
+        "version" : "0.8.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "avfoundation-combine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/AVFoundation-Combine",
+      "state" : {
+        "branch" : "main",
+        "revision" : "637ba786561616297554365d12402414d5024335"
+      }
+    },
+    {
+      "identity" : "combinecocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CombineCommunity/CombineCocoa",
+      "state" : {
+        "revision" : "4e262c2f9fb1cee1cb3be5717f7e6b55eb823971",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "orientationkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/OrientationKit",
+      "state" : {
+        "revision" : "491927e9cc835c0fcc7eac349c0245024f5d8579",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "a09839348486db8866f85a727b8550be1d671c50",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "21ec1d717c07cea5a026979cb0471dd95c7087e7",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swiftui-photopicker",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/inamiy/SwiftUI-PhotoPicker",
+      "state" : {
+        "branch" : "main",
+        "revision" : "7fa6cc560e9c48dca41de152686ebd572eb88edf"
+      }
+    },
+    {
+      "identity" : "vectormath",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/VectorMath",
+      "state" : {
+        "revision" : "2de2585f455dc8e15d642ca51b29b1917e68fd1e",
+        "version" : "0.4.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "ef8e14e7ce1c0c304c644c6ba365d06c468ded6b",
+        "version" : "0.3.3"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ build-VideoPlayer:
 	cd Examples/VideoPlayer/ && \
 	xcodebuild build -scheme Actomaton-VideoPlayer $(DESTINATION) | xcpretty
 
+.PHONY: build-all
+build-all: build-package build-SwiftUI-Basic build-SwiftUI-Gallery build-UIKit-Gallery build-Favorite-Sync build-VideoPlayer
+
 # e.g.
 # make universal-link
 # make universal-link path=counter?count=3

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inamiy/Actomaton",
       "state" : {
-        "branch" : "main",
-        "revision" : "47a3b125a847a1b92cc1a37914a3e61d171cbea2"
+        "revision" : "e51e5ea17f3fb31f4d98eaab1d044f33d4c02386",
+        "version" : "0.8.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 import Foundation
 import PackageDescription
@@ -19,10 +19,10 @@ let package = Package(
     ],
     dependencies: [
 //        .package(name: "Actomaton", path: "../Actomaton"), // local
-        .package(url: "https://github.com/inamiy/Actomaton", .branch("main")),
+        .package(url: "https://github.com/inamiy/Actomaton", from: "0.8.0"),
         .package(url: "https://github.com/inamiy/OrientationKit", from: "0.1.0"),
-        .package(url: "https://github.com/inamiy/SwiftUI-PhotoPicker", .branch("main")),
-        .package(url: "https://github.com/inamiy/AVFoundation-Combine", .branch("main")),
+        .package(url: "https://github.com/inamiy/SwiftUI-PhotoPicker", branch: "main"),
+        .package(url: "https://github.com/inamiy/AVFoundation-Combine", branch: "main"),
         .package(url: "https://github.com/nicklockwood/VectorMath", from: "0.4.1")
     ],
     targets: [


### PR DESCRIPTION
This PR updates all example apps using [Actomaton 0.8.0](https://github.com/Actomaton/Actomaton/releases/tag/0.8.0) for Swift 5.9 / Xcode 15.0.