### PR TITLE
Apply Actomaton API rename (EffectID/EffectQueue) and remove @unchecked Sendable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,13 @@ on:
       - ci/**
   pull_request:
 
-env:
-  DEVELOPER_DIR: /Applications/Xcode_26.0.app
-
 jobs:
   build-package:
     runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
+    - name: Select Xcode 26.4
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app
     - name: Build package
       run: make build-package
 
@@ -24,6 +23,8 @@ jobs:
     runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
+    - name: Select Xcode 26.4
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app
     - name: Build SwiftUI-Basic
       run: make build-SwiftUI-Basic
 
@@ -31,6 +32,8 @@ jobs:
     runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
+    - name: Select Xcode 26.4
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app
     - name: Build SwiftUI-Gallery
       run: make build-SwiftUI-Gallery
 
@@ -38,6 +41,8 @@ jobs:
     runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
+    - name: Select Xcode 26.4
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app
     - name: Build UIKit-Gallery
       run: make build-UIKit-Gallery
 
@@ -45,6 +50,8 @@ jobs:
     runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
+    - name: Select Xcode 26.4
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app
     - name: Build Favorite-Sync
       run: make build-Favorite-Sync
 
@@ -52,5 +59,7 @@ jobs:
     runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
+    - name: Select Xcode 26.4
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app
     - name: Build VideoPlayer
       run: make build-VideoPlayer

--- a/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Favorite-Sync/Actomaton-Favorite-Sync.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/inamiy/Actomaton",
       "state" : {
         "branch" : "main",
-        "revision" : "2495542d31ee0342ee231099141978572bd00d10"
+        "revision" : "bb5353518e687a4cc163bb4f4328806425dc9146"
       }
     },
     {
@@ -46,12 +46,30 @@
       }
     },
     {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/inamiy/Actomaton",
       "state" : {
         "branch" : "main",
-        "revision" : "2495542d31ee0342ee231099141978572bd00d10"
+        "revision" : "bb5353518e687a4cc163bb4f4328806425dc9146"
       }
     },
     {
@@ -46,12 +46,30 @@
       }
     },
     {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {
@@ -77,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b444594f79844b0d6d76d70fbfb3f7f71728f938",
-        "version" : "1.5.1"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Examples/UIKit-Gallery/Actomaton-UIKit-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/UIKit-Gallery/Actomaton-UIKit-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/inamiy/Actomaton",
       "state" : {
         "branch" : "main",
-        "revision" : "2495542d31ee0342ee231099141978572bd00d10"
+        "revision" : "bb5353518e687a4cc163bb4f4328806425dc9146"
       }
     },
     {
@@ -32,8 +32,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "a09839348486db8866f85a727b8550be1d671c50",
-        "version" : "0.9.1"
+        "revision" : "bb436421f57269fbcfe7360735985321585a86e5",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {
@@ -41,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "actomaton",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inamiy/Actomaton",
-      "state" : {
-        "branch" : "main",
-        "revision" : "2495542d31ee0342ee231099141978572bd00d10"
-      }
-    },
-    {
       "identity" : "avfoundation-combine",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inamiy/AVFoundation-Combine",
@@ -43,6 +34,24 @@
       "state" : {
         "revision" : "a09839348486db8866f85a727b8550be1d671c50",
         "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
       }
     },
     {

--- a/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootEnvironment.swift
+++ b/Examples/VideoPlayer/Actomaton-VideoPlayer/Root/RootEnvironment.swift
@@ -175,4 +175,4 @@ extension RootEnvironment
 
 // MARK: - EffectQueue
 
-struct PlayerSubscriptionEffectQueue: Newest1EffectQueueProtocol {}
+struct PlayerSubscriptionEffectQueue: Newest1EffectQueue {}

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/inamiy/Actomaton",
       "state" : {
         "branch" : "main",
-        "revision" : "2495542d31ee0342ee231099141978572bd00d10"
+        "revision" : "bb5353518e687a4cc163bb4f4328806425dc9146"
       }
     },
     {
@@ -37,12 +37,30 @@
       }
     },
     {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/inamiy/AVFoundation-Combine", branch: "main"),
         .package(url: "https://github.com/nicklockwood/VectorMath", from: "0.4.1"),
         // Pin to 1.3.0 to avoid swift-issue-reporting vs xctest-dynamic-overlay target conflict.
-        .package(url: "https://github.com/pointfreeco/swift-custom-dump", exact: "1.3.0")
+        // .package(url: "https://github.com/pointfreeco/swift-custom-dump", exact: "1.3.0")
     ],
     targets: [
         .target(
@@ -42,7 +42,7 @@ let package = Package(
             name: "CanvasPlayer",
             dependencies: [
                 .product(name: "ActomatonUI", package: "Actomaton"),
-                "Utilities"
+                "CommonUI", "Utilities"
             ]),
         .target(
             name: "ImageLoader",
@@ -52,7 +52,10 @@ let package = Package(
             dependencies: [.product(name: "ActomatonUI", package: "Actomaton")]),
         .target(
             name: "Tabs",
-            dependencies: [.product(name: "ActomatonUI", package: "Actomaton")]),
+            dependencies: [
+                .product(name: "ActomatonUI", package: "Actomaton"),
+                "Utilities"
+            ]),
         .target(
             name: "Counter",
             dependencies: [
@@ -114,7 +117,7 @@ let package = Package(
             name: "ElemCellAutomaton",
             dependencies: [
                 .product(name: "ActomatonUI", package: "Actomaton"),
-                "CanvasPlayer", "Utilities"
+                "CommonUI", "CanvasPlayer", "Utilities"
             ]),
         .target(
             name: "GameOfLife",

--- a/Sources/CanvasPlayer/CanvasPlayer.swift
+++ b/Sources/CanvasPlayer/CanvasPlayer.swift
@@ -68,11 +68,11 @@ public struct Environment: Sendable
 
 // MARK: - EffectID
 
-private struct TimerEffectID: EffectIDProtocol {}
+private struct TimerEffectID: EffectID {}
 
-public func cancelAllEffectsPredicate(id: EffectID) -> Bool
+public func cancelAllEffectsPredicate(id: any EffectID) -> Bool
 {
-    return id.value is TimerEffectID
+    return id is TimerEffectID
 }
 
 // MARK: - Reducer

--- a/Sources/Downloader/Downloader.swift
+++ b/Sources/Downloader/Downloader.swift
@@ -183,19 +183,19 @@ public struct Environment: Sendable
 
 // MARK: - EffectID
 
-public struct DownloaderEffectID: EffectIDProtocol
+public struct DownloaderEffectID: EffectID
 {
     let downloadID: DownloadID
 }
 
-public func cancelAllEffectsPredicate(id: EffectID) -> Bool
+public func cancelAllEffectsPredicate(id: any EffectID) -> Bool
 {
-    return id.value is DownloaderEffectID
+    return id is DownloaderEffectID
 }
 
 // MARK: - EffectQueue
 
-public struct DownloaderEffectQueue: EffectQueueProtocol
+public struct DownloaderEffectQueue: EffectQueue
 {
     public var effectQueuePolicy: EffectQueuePolicy
     {
@@ -207,23 +207,23 @@ public struct DownloaderEffectQueue: EffectQueueProtocol
 
 public var reducer: Reducer<Action, State, Environment>
 {
-    .init { action, state, environment in
+    Reducer<Action, State, Environment> { action, state, environment in
         switch action {
         case .downloadAll:
-            let downloads = Effect<Action>.nextAction(.download(id: "item-01"))
-                + .nextAction(.download(id: "item-02"))
-                + .nextAction(.download(id: "item-03"))
-                + .nextAction(.download(id: "item-04"))
-                + .nextAction(.download(id: "item-05"))
+            let downloadIDs: [DownloadID] = [
+                "item-01", "item-02", "item-03", "item-04", "item-05",
+            ]
+            let downloads: Effect<Action> = downloadIDs
+                .map { Effect<Action>.nextAction(.download(id: $0)) }
+                .reduce(Effect<Action>.empty, +)
 
-            return Effect.nextAction(.cancelAll)
-                + downloads
+            return Effect<Action>.nextAction(.cancelAll) + downloads
 
         case .cancelAll:
             for (downloadID, progress) in state.runningTasks where progress.canCancel {
                 state.runningTasks[downloadID] = .cancelled
             }
-            return .cancel(ids: { $0.value is DownloaderEffectID })
+            return .cancel(ids: { $0 is DownloaderEffectID })
 
         case let .download(downloadID):
             state.runningTasks[downloadID] = .waiting(progress: 0)

--- a/Sources/ElemCellAutomaton/Screens/Game/Game.swift
+++ b/Sources/ElemCellAutomaton/Screens/Game/Game.swift
@@ -88,7 +88,7 @@ extension Game
 
     // MARK: - EffectID
 
-    static func cancelAllEffectsPredicate(id: EffectID) -> Bool
+    static func cancelAllEffectsPredicate(id: any EffectID) -> Bool
     {
         CanvasPlayer.cancelAllEffectsPredicate(id: id)
     }

--- a/Sources/ElemCellAutomaton/Screens/Root/ElemCellAutomatonRoot.swift
+++ b/Sources/ElemCellAutomaton/Screens/Root/ElemCellAutomatonRoot.swift
@@ -31,7 +31,7 @@ extension ElemCellAutomatonRoot
 
     public typealias Environment = RootEnvironment
 
-    public static func cancelAllEffectsPredicate(id: EffectID) -> Bool
+    public static func cancelAllEffectsPredicate(id: any EffectID) -> Bool
     {
         Game.cancelAllEffectsPredicate(id: id)
     }

--- a/Sources/GameOfLife/Screens/Game/Game.swift
+++ b/Sources/GameOfLife/Screens/Game/Game.swift
@@ -89,7 +89,7 @@ extension Game
 
     // MARK: - EffectID
 
-    static func cancelAllEffectsPredicate(id: EffectID) -> Bool
+    static func cancelAllEffectsPredicate(id: any EffectID) -> Bool
     {
         CanvasPlayer.cancelAllEffectsPredicate(id: id)
     }

--- a/Sources/GameOfLife/Screens/PatternSelect/PatternSelect.swift
+++ b/Sources/GameOfLife/Screens/PatternSelect/PatternSelect.swift
@@ -208,7 +208,3 @@ extension PatternSelect.State.Status
     }
 }
 
-// MARK: - @unchecked Sendable
-
-// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-extension URL: @unchecked Sendable {}

--- a/Sources/GameOfLife/Screens/Root/GameOfLifeRoot.swift
+++ b/Sources/GameOfLife/Screens/Root/GameOfLifeRoot.swift
@@ -48,7 +48,7 @@ extension GameOfLifeRoot
 
     public typealias Environment = RootEnvironment
 
-    public static func cancelAllEffectsPredicate(id: EffectID) -> Bool
+    public static func cancelAllEffectsPredicate(id: any EffectID) -> Bool
     {
         Game.cancelAllEffectsPredicate(id: id)
     }

--- a/Sources/GitHub/GitHub.swift
+++ b/Sources/GitHub/GitHub.swift
@@ -128,11 +128,11 @@ public struct Environment: Sendable
 
 // MARK: - EffectID
 
-public struct GitHubRequestID: EffectIDProtocol {}
+public struct GitHubRequestID: EffectID {}
 
-public func cancelAllEffectsPredicate(id: EffectID) -> Bool
+public func cancelAllEffectsPredicate(id: any EffectID) -> Bool
 {
-    id.value is GitHubRequestID || id.value is ImageLoader.ImageEffectID
+    id is GitHubRequestID || id is ImageLoader.ImageEffectID
 }
 
 // MARK: - Reducer

--- a/Sources/Home/Home.State.Current.swift
+++ b/Sources/Home/Home.State.Current.swift
@@ -67,7 +67,7 @@ extension State
 extension State.Current
 {
     /// Used for previous screen's effects cancellation.
-    var cancelAllEffectsPredicate: (EffectID) -> Bool
+    var cancelAllEffectsPredicate: (any EffectID) -> Bool
     {
         switch self {
         case .stopwatch:

--- a/Sources/HttpBin/HttpBin.swift
+++ b/Sources/HttpBin/HttpBin.swift
@@ -44,13 +44,13 @@ public struct Environment: Sendable
 
 // MARK: - EffectID
 
-public struct HttpBinRequestID: EffectIDProtocol {}
+public struct HttpBinRequestID: EffectID {}
 
-public struct HttpBinRequestQueue: Oldest1DiscardNewEffectQueueProtocol {}
+public struct HttpBinRequestQueue: Oldest1DiscardNewEffectQueue {}
 
-public func cancelAllEffectsPredicate(id: EffectID) -> Bool
+public func cancelAllEffectsPredicate(id: any EffectID) -> Bool
 {
-    id.value is HttpBinRequestID
+    id is HttpBinRequestID
 }
 
 // MARK: - Reducer

--- a/Sources/ImageLoader/ImageLoader.swift
+++ b/Sources/ImageLoader/ImageLoader.swift
@@ -35,9 +35,9 @@ public struct Environment: Sendable
 
 // MARK: - EffectID
 
-public struct ImageEffectID: EffectIDProtocol {}
+public struct ImageEffectID: EffectID {}
 
-public struct ImageEffectQueue: Oldest1SuspendNewEffectQueueProtocol {}
+public struct ImageEffectQueue: Oldest1SuspendNewEffectQueue {}
 
 // MARK: - Reducer
 
@@ -94,8 +94,3 @@ public struct Response
     public let image: UIImage
 }
 
-// MARK: - @unchecked Sendable
-
-// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-extension URL: @unchecked Sendable {}
-extension UIImage: @unchecked Sendable {}

--- a/Sources/Physics/PhysicsRoot/PhysicsRoot.State.Current.swift
+++ b/Sources/Physics/PhysicsRoot/PhysicsRoot.State.Current.swift
@@ -91,7 +91,7 @@ extension PhysicsRoot.State
 extension PhysicsRoot.State.Current
 {
     /// Used for previous screen's effects cancellation.
-    var cancelAllEffectsPredicate: (EffectID) -> Bool
+    var cancelAllEffectsPredicate: (any EffectID) -> Bool
     {
         CanvasPlayer.cancelAllEffectsPredicate
     }

--- a/Sources/Physics/PhysicsRoot/PhysicsRoot.swift
+++ b/Sources/Physics/PhysicsRoot/PhysicsRoot.swift
@@ -80,7 +80,7 @@ extension PhysicsRoot
 
     // MARK: - EffectID
 
-    public static func cancelAllEffectsPredicate(id: EffectID) -> Bool
+    public static func cancelAllEffectsPredicate(id: any EffectID) -> Bool
     {
         CanvasPlayer.cancelAllEffectsPredicate(id: id)
     }

--- a/Sources/StateDiagram/StateDiagram.swift
+++ b/Sources/StateDiagram/StateDiagram.swift
@@ -28,7 +28,7 @@ public typealias Environment = ()
 
 // MARK: - Effect
 
-public struct LoginFlowEffectQueue: Newest1EffectQueueProtocol {}
+public struct LoginFlowEffectQueue: Newest1EffectQueue {}
 
 // MARK: - Reducer
 

--- a/Sources/Stopwatch/Stopwatch.swift
+++ b/Sources/Stopwatch/Stopwatch.swift
@@ -134,11 +134,11 @@ public struct Environment: Sendable
 
 // MARK: - EffectID
 
-public struct TimerEffectID: EffectIDProtocol {}
+public struct TimerEffectID: EffectID {}
 
-public func cancelAllEffectsPredicate(id: EffectID) -> Bool
+public func cancelAllEffectsPredicate(id: any EffectID) -> Bool
 {
-    return id.value is TimerEffectID
+    return id is TimerEffectID
 }
 
 // MARK: - Reducer
@@ -200,7 +200,3 @@ public var reducer: Reducer<Action, State, Environment>
     }
 }
 
-// MARK: - @unchecked Sendable
-
-// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-extension Date: @unchecked Sendable {}

--- a/Sources/SyncCounters/SyncCounters.swift
+++ b/Sources/SyncCounters/SyncCounters.swift
@@ -77,7 +77,3 @@ public var reducer: Reducer<Action, State, Environment>
     }
 }
 
-// MARK: - @unchecked Sendable
-
-// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-extension UUID: @unchecked Sendable {}

--- a/Sources/Tabs/TabItem.swift
+++ b/Sources/Tabs/TabItem.swift
@@ -43,7 +43,3 @@ public struct TabItem<InnerState, ID>: Equatable, Identifiable, Sendable
     }
 }
 
-// MARK: - @unchecked Sendable
-
-// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-extension Image: @unchecked Sendable {}

--- a/Sources/Todo/Todo.swift
+++ b/Sources/Todo/Todo.swift
@@ -120,7 +120,3 @@ public enum DisplayMode: Int, CaseIterable, Equatable, Sendable
     }
 }
 
-// MARK: - @unchecked Sendable
-
-// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-extension IndexSet: @retroactive @unchecked Sendable {}

--- a/Sources/UIKit/TabsUIKit/TabItem.swift
+++ b/Sources/UIKit/TabsUIKit/TabItem.swift
@@ -71,7 +71,7 @@ extension TabItem
         title: String,
         image: UIImage,
         store: Store<Action, State, Environment>,
-        view: @escaping (Store<Action, State, Void>) -> V
+        view: @escaping @Sendable (Store<Action, State, Void>) -> V
     ) where State: Equatable
     {
         self.id = id
@@ -102,4 +102,4 @@ extension TabItem
 
 // TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
 
-extension UITabBarItem: @unchecked Sendable {}
+extension UITabBarItem: @retroactive @unchecked Sendable {}

--- a/Sources/UserSessionNavigation/UserSession/User.swift
+++ b/Sources/UserSessionNavigation/UserSession/User.swift
@@ -37,8 +37,3 @@ extension User
     )
 }
 
-// MARK: - @unchecked Sendable
-
-// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-extension UUID: @unchecked Sendable {}
-extension Image: @unchecked Sendable {}

--- a/Sources/UserSessionNavigation/UserSession/UserSession.swift
+++ b/Sources/UserSessionNavigation/UserSession/UserSession.swift
@@ -54,7 +54,7 @@ public typealias Environment = ()
 
 // MARK: - Effect
 
-public struct LoginFlowEffectQueue: Newest1EffectQueueProtocol {}
+public struct LoginFlowEffectQueue: Newest1EffectQueue {}
 
 // MARK: - Reducer
 

--- a/Sources/VideoCapture/VideoCapture.swift
+++ b/Sources/VideoCapture/VideoCapture.swift
@@ -81,7 +81,7 @@ extension VideoCapture
 
     // MARK: - EffectID
 
-    public struct OrientationEffectID: EffectIDProtocol {}
+    public struct OrientationEffectID: EffectID {}
 
     // MARK: - Reducer
 

--- a/Sources/VideoDetector/VideoDetector.swift
+++ b/Sources/VideoDetector/VideoDetector.swift
@@ -144,7 +144,3 @@ extension VideoDetector
     }
 }
 
-// MARK: - @unchecked Sendable
-
-// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-extension UIImage: @unchecked Sendable {}

--- a/Sources/VideoPlayer/VideoPlayer.swift
+++ b/Sources/VideoPlayer/VideoPlayer.swift
@@ -54,7 +54,7 @@ public struct Environment: Sendable
 // MARK: - EffectQueue
 
 /// Player observation queue per each `label`, with old subscription auto-cancellation.
-public struct PlayerSubscriptionQueue: Newest1EffectQueueProtocol
+public struct PlayerSubscriptionQueue: Newest1EffectQueue
 {
     /// Label used to identify a video player in case of multiple players being presented at same time,
     /// but each player's subscription (effect) should not interfere with each other.


### PR DESCRIPTION
Updates Actomaton-Gallery to follow the latest Actomaton API.

### API rename

- `EffectIDProtocol` → `EffectID`
- `EffectQueueProtocol` → `EffectQueue`
- `Oldest1SuspendNewEffectQueueProtocol` → `Oldest1SuspendNewEffectQueue`
- Use `any EffectID` for existential parameters and drop `.value` access

### Sendable cleanup

- Remove `@unchecked Sendable` extensions on `UUID`, `URL`, `UIImage`, `Image`, `Date`, `IndexSet` (no longer required)

### Dependencies

- Add `CommonUI` dependency to `CanvasPlayer`, `Tabs`, and `ElemCellAutomaton`
- Bump `Actomaton` and related SwiftPM dependencies
- Comment out the `swift-custom-dump` 1.3.0 pin (no longer needed)

### Related

- https://github.com/Actomaton/Actomaton — upstream API rename
