### PR TITLE
Reduce build warnings (iOS 17/18 deprecations, AnyHashable, content closures)

### DIFF
--- a/Sources/CanvasPlayer/CanvasView.swift
+++ b/Sources/CanvasPlayer/CanvasView.swift
@@ -69,7 +69,7 @@ public struct CanvasView<CanvasState>: View
         )
         .clipped()
         .border(Color.green, width: 2)
-        .onChange(of: geometrySize) { newValue in
+        .onChange(of: geometrySize) { _, newValue in
             Debug.print("===> onChange(of: self.geometrySize) = \(newValue)")
 
             if self.canvasSize.state != newValue {

--- a/Sources/GameOfLife/Models/Pattern.swift
+++ b/Sources/GameOfLife/Models/Pattern.swift
@@ -101,7 +101,7 @@ public struct Pattern: Identifiable, Equatable, Sendable
 
     public static func parseRunLengthEncoded(url: URL) throws -> Pattern
     {
-        let text = try String(contentsOf: url)
+        let text = try String(contentsOf: url, encoding: .utf8)
 
         let assetName = url.deletingPathExtension().lastPathComponent
         let cells = try parseRunLengthEncoded(string: text)

--- a/Sources/Physics/World/ObjectLike.swift
+++ b/Sources/Physics/World/ObjectLike.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 import VectorMath
 
@@ -31,10 +32,5 @@ protocol _ObjectLike: ObjectLike
     var force: Vector2 { get set }
 }
 
-public typealias ObjectLikeID = AnyHashable
+public typealias ObjectLikeID = UUID
 public typealias Mass = Scalar
-
-// MARK: - @unchecked Sendable
-
-// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
-extension AnyHashable: @retroactive @unchecked Sendable {}

--- a/Sources/UIKit/ExampleListUIKit/ExampleListBuilder.swift
+++ b/Sources/UIKit/ExampleListUIKit/ExampleListBuilder.swift
@@ -15,7 +15,7 @@ public enum ExampleListBuilder
 
         let exampleListVC = HostingViewController(
             store: exampleListStore,
-            content: ExampleListView.init
+            content: { ExampleListView(store: $0) }
         )
 
         exampleListStore.subscribeRoutes { [weak exampleListVC] route in

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/CounterExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/CounterExample.swift
@@ -18,7 +18,7 @@ public struct CounterExample: Example
                 reducer: Counter.reducer,
                 environment: ()
             ),
-            content: CounterView.init
+            content: { CounterView(store: $0) }
         )
     }
 }

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/GameOfLifeExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/GameOfLifeExample.swift
@@ -20,7 +20,7 @@ public struct GameOfLifeExample: Example
                 environment: .live
             )
             .noEnvironment,
-            content: GameOfLife.RootView.init
+            content: { GameOfLife.RootView(store: $0) }
         )
     }
 }

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/GitHubExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/GitHubExample.swift
@@ -20,7 +20,7 @@ public struct GitHubExample: Example
                 environment: .live
             )
             .noEnvironment,
-            content: GitHubView.init
+            content: { GitHubView(store: $0) }
         )
     }
 }

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/PhysicsExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/PhysicsExample.swift
@@ -37,7 +37,7 @@ public struct PhysicsExample: Example
                 })
             )
             .noEnvironment,
-            content: PhysicsRootView.init
+            content: { PhysicsRootView(store: $0) }
         )
     }
 }

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/StateDiagramExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/StateDiagramExample.swift
@@ -18,7 +18,7 @@ public struct StateDiagramExample: Example
                 reducer: StateDiagram.reducer,
                 environment: ()
             ),
-            content: StateDiagramView.init
+            content: { StateDiagramView(store: $0) }
         )
     }
 }

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/StopwatchExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/StopwatchExample.swift
@@ -19,7 +19,7 @@ public struct StopwatchExample: Example
                 environment: .live
             )
             .noEnvironment,
-            content: StopwatchView.init
+            content: { StopwatchView(store: $0) }
         )
     }
 }

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/TodoExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/TodoExample.swift
@@ -18,7 +18,7 @@ public struct TodoExample: Example
                 reducer: Todo.reducer,
                 environment: ()
             ),
-            content: TodoView.init
+            content: { TodoView(store: $0) }
         )
     }
 }

--- a/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/VideoDetectorExample.swift
+++ b/Sources/UIKit/ExamplesUIKit/ExampleList/Examples/SwiftUI/VideoDetectorExample.swift
@@ -18,7 +18,7 @@ public struct VideoDetectorExample: Example
                 reducer: VideoDetector.reducer,
                 environment: ()
             ),
-            content: VideoDetectorView.init
+            content: { VideoDetectorView(store: $0) }
         )
     }
 }

--- a/Sources/VideoPlayerMulti/VideoPlayerMultiView.swift
+++ b/Sources/VideoPlayerMulti/VideoPlayerMultiView.swift
@@ -60,7 +60,7 @@ public struct VideoPlayerMultiView: View
                 store.environment.videoPlayer2.setPlayer(makePlayer())
             }
         }
-        .onChange(of: viewStore.displayMode) { _ in
+        .onChange(of: viewStore.displayMode) { _, _ in
             // Re-subscribe each player on `displayMode` changes.
             childStore1.send(.subscribePlayer)
             childStore2.send(.subscribePlayer)


### PR DESCRIPTION
Fixes a batch of compiler warnings from the most recent clean build (49 → 5 warnings).

### Deprecated APIs

- `onChange(of:perform:)` (iOS 17) → two-parameter form in `CanvasView` and `VideoPlayerMultiView`
- `String(contentsOf:)` (iOS 18) → pass explicit `encoding: .utf8` in `GameOfLife/Pattern.swift`

### Sendable / Concurrency

- Replace `public typealias ObjectLikeID = AnyHashable` with `UUID` so `Bob`, `CircleObject`, `LineObject`, and `World.CanvasState.DragState` are concretely Sendable. Drops the last `extension AnyHashable: @retroactive @unchecked Sendable {}` workaround.
- Shorten `HostingViewController(content:)` argument from `View.init` reference to `{ View(store: $0) }` closure across 9 UIKit example builders, silencing the "converting non-Sendable function value to `@MainActor @Sendable`" warning.

### Remaining

Five warnings still pending and deferred to follow-up PRs:

- `NavigationLink(destination:isActive:label:)` in `HomeView` and `PhysicsRootView` — needs `NavigationView` → `NavigationStack` migration.
- `UIScreen.windows`, `AVCaptureVideoOrientation`, `videoOrientation` in `VideoPreviewView` — needs `AVCaptureDeviceRotationCoordinator` rewrite.
