### PR TITLE
Examples: restore Inject hot-reload under Xcode 16.3+ / Swift 6

### DIFF
--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1F9153AB28B04443003FA573 /* Inject in Frameworks */ = {isa = PBXBuildFile; productRef = 1F9153AA28B04443003FA573 /* Inject */; };
+		1FCAA1492F9E00FC008808F9 /* InjectedAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FCAA1482F9E00F4008808F9 /* InjectedAppView.swift */; };
 		1FE7A1662711C9AA0048FFD8 /* SwiftUI-Gallery in Frameworks */ = {isa = PBXBuildFile; productRef = 1FE7A1652711C9AA0048FFD8 /* SwiftUI-Gallery */; };
 		332642E726E4056F00438A10 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332642E226E4056F00438A10 /* DemoApp.swift */; };
 		3326433E26E4094200438A10 /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3326433C26E4094200438A10 /* AppView.swift */; };
@@ -17,6 +18,7 @@
 
 /* Begin PBXFileReference section */
 		1F80CC0C27428A5E001AA7B6 /* Actomaton-Gallery.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Actomaton-Gallery.entitlements"; sourceTree = "<group>"; };
+		1FCAA1482F9E00F4008808F9 /* InjectedAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectedAppView.swift; sourceTree = "<group>"; };
 		332642E226E4056F00438A10 /* DemoApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoApp.swift; sourceTree = "<group>"; };
 		3326433C26E4094200438A10 /* AppView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
 		339BF50727E4B62B009A90ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = "Actomaton-Gallery/Info.plist"; sourceTree = "<group>"; };
@@ -63,6 +65,7 @@
 			children = (
 				1F80CC0C27428A5E001AA7B6 /* Actomaton-Gallery.entitlements */,
 				332642E226E4056F00438A10 /* DemoApp.swift */,
+				1FCAA1482F9E00F4008808F9 /* InjectedAppView.swift */,
 				3326433C26E4094200438A10 /* AppView.swift */,
 				33E8F81E26E3B375009CC65D /* Assets.xcassets */,
 				33E8F82026E3B375009CC65D /* Preview Content */,
@@ -164,6 +167,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3326433E26E4094200438A10 /* AppView.swift in Sources */,
+				1FCAA1492F9E00FC008808F9 /* InjectedAppView.swift in Sources */,
 				332642E726E4056F00438A10 /* DemoApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzysztofzablocki/Inject",
       "state" : {
-        "revision" : "a45509eac083b42afd4b6fd00a93a2b53f99f3eb",
-        "version" : "1.2.1"
+        "revision" : "f53380e986a8b056e37d7ce9ca68de610b8415ef",
+        "version" : "1.6.0"
       }
     },
     {

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/AppView.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/AppView.swift
@@ -27,68 +27,39 @@ import ElemCellAutomaton
 import GameOfLife
 import Physics
 
-@MainActor
-struct InjectedAppView: View
-{
-    @ObserveInjection var inject
-
-    var body: some View
-    {
-        AppView()
-
-//        RootView_Previews.makePreviews(state: .initialState, environment: .live, isMultipleScreens: false)
-//        HomeView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
-//
-//        ----------------------------------------
-//        Per screen
-//        ----------------------------------------
-//        CounterView_Previews.previews
-//        SyncCountersView_Previews.previews
-//        AnimationDemoView_Previews.previews
-//        ColorFilterView_Previews.previews
-//        TodoView_Previews.previews
-//        StateDiagramView_Previews.previews
-//        StopwatchView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
-//        HttpBinView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
-//        GitHubView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
-//        DownloaderView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
-//        VideoPlayerView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
-//        VideoPlayerMultiView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
-//        VideoDetectorView_Previews.previews
-//        ElemCellAutomaton_RootView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
-//        GameOfLife_RootView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
-//        PhysicsRootView_Previews.makePreviews(state: .doublePendulum, environment: .live, isMultipleScreens: false)
-    }
-}
-
 /// Topmost container view of the app which holds `Store` as a single source of truth.
 @MainActor
 struct AppView: View
 {
-    private var store: Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>, HomeEnvironment>
+    let store: Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>, HomeEnvironment>
 
-    init()
+    var body: some View
     {
-            let initialHomeState = Home.State(
-//                current: .counter(.init(count: 0)),
-//                current: .syncCounters(.init(common: .init(numberOfCounters: 1), counterState: .init(count: 0))),
-//                current: .physics(.init(current: nil)),
-//                current: .physics(.gravityUniverse),
-//                current: .physics(.gravitySurface),
-//                current: .physics(.collision),
-//                current: .physics(.pendulum),
-//                current: .physics(.doublePendulum),
-//                current: .physics(.galtonBoard),
-//                current: .elemCellAutomaton(.init(pattern: .init(rule: 110), cellLength: 5, timerInterval: 0.05)),
-//                current: .gameOfLife(.init(pattern: .glider, cellLength: 5, timerInterval: 0.05)),
-//                current: .videoPlayerMulti(.init(displayMode: .singleSyncedPlayer)),
+        DebugRootView<Root.RootView>(store: self.store)
+    }
 
-                current: nil,
-                usesTimeTravel: true,
-                isDebuggingTab: false
-            )
+    static func makeStore() -> Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>, HomeEnvironment>
+    {
+        let initialHomeState = Home.State(
+//            current: .counter(.init(count: 0)),
+//            current: .syncCounters(.init(common: .init(numberOfCounters: 1), counterState: .init(count: 0))),
+//            current: .physics(.init(current: nil)),
+//            current: .physics(.gravityUniverse),
+//            current: .physics(.gravitySurface),
+//            current: .physics(.collision),
+//            current: .physics(.pendulum),
+//            current: .physics(.doublePendulum),
+//            current: .physics(.galtonBoard),
+//            current: .elemCellAutomaton(.init(pattern: .init(rule: 110), cellLength: 5, timerInterval: 0.05)),
+//            current: .gameOfLife(.init(pattern: .glider, cellLength: 5, timerInterval: 0.05)),
+//            current: .videoPlayerMulti(.init(displayMode: .singleSyncedPlayer)),
 
-        self.store = Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>, HomeEnvironment>(
+            current: nil,
+            usesTimeTravel: true,
+            isDebuggingTab: false
+        )
+
+        return Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>, HomeEnvironment>(
             state: DebugRoot.State(inner: Root.State.initialState(homeState: initialHomeState)),
             reducer: DebugRoot.reducer(inner: Root.reducer()),
             environment: .live,
@@ -100,11 +71,6 @@ struct AppView: View
 #endif
             }()
         )
-    }
-
-    var body: some View
-    {
-        DebugRootView<Root.RootView>(store: self.store)
     }
 }
 

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/DemoApp.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/DemoApp.swift
@@ -4,10 +4,16 @@ import Inject
 @main
 struct DemoApp: App
 {
+    /// Owned here (not in `AppView`) so it survives Inject hot-reload redraws.
+    /// If the `Store` were constructed inside a view that `@ObserveInjection`
+    /// re-renders, every code edit would tear down the old `Store` while its
+    /// in-flight Actomaton effects were still running, racing into a crash.
+    @State private var store = AppView.makeStore()
+
     var body: some Scene
     {
         WindowGroup {
-            InjectedAppView().enableInjection()
+            InjectedAppView(store: store)
         }
     }
 }

--- a/Examples/SwiftUI-Gallery/Actomaton-Gallery/InjectedAppView.swift
+++ b/Examples/SwiftUI-Gallery/Actomaton-Gallery/InjectedAppView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+import ActomatonUI
+import Tabs
+import Home
+import Root
+import DebugRoot
+import UserSession
+import CommonEffects
+import LiveEnvironments
+import Inject
+
+// Additional examples import.
+import Counter
+import SyncCounters
+import AnimationDemo
+import ColorFilter
+import Todo
+import StateDiagram
+import Stopwatch
+import HttpBin
+import GitHub
+import Downloader
+import VideoPlayer
+import VideoPlayerMulti
+import VideoDetector
+import ElemCellAutomaton
+import GameOfLife
+import Physics
+
+/// Inject hot-reload host and the edit-target view for hot reload.
+///
+/// ## How to activate hot-reloading
+///
+/// 1. Install `InjectionIII.app` from https://github.com/johnno1962/InjectionIII/releases
+///    into `/Applications` (or `InjectionNext.app` from the same author as a
+///    drop-in replacement that doesn't depend on Xcode build logs).
+/// 2. Launch `InjectionIII`, choose `Open Project…` and select this workspace
+///    or the enclosing `Package.swift`.
+/// 3. Run the app on the iOS Simulator in `Debug`. The console should print
+///    `💉 InjectionIII connected …` once attached.
+/// 4. Edit this view's body and save — the simulator re-renders without a rebuild.
+///
+/// Project-side prerequisites already wired up here:
+/// - `OTHER_LDFLAGS = -Xlinker -interposable` on the app target's Debug config.
+/// - `EMIT_FRONTEND_COMMAND_LINES = YES` on Debug (required for Xcode 16.3+,
+///   which otherwise no longer logs Swift compile commands that InjectionIII
+///   parses).
+/// - `Inject` 1.6.0+ — earlier versions do not redraw reliably under Swift 6
+///   strict concurrency.
+///
+/// - Important:
+/// `@ObserveInjection` (and `.enableInjection()`) must be applied
+/// **inside the body of the view whose code you are editing**, not from a parent.
+@MainActor
+struct InjectedAppView: View
+{
+    @ObserveInjection var inject
+
+    let store: Store<DebugRoot.Action<Root.Action>, DebugRoot.State<Root.State>, HomeEnvironment>
+
+    @ViewBuilder
+    private var _body: some View {
+        AppView(store: store)
+
+//        RootView_Previews.makePreviews(state: .initialState, environment: .live, isMultipleScreens: false)
+//        HomeView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
+//
+//        ----------------------------------------
+//        Per screen
+//        ----------------------------------------
+//        CounterView_Previews.previews
+//        SyncCountersView_Previews.previews
+//        AnimationDemoView_Previews.previews
+//        ColorFilterView_Previews.previews
+//        TodoView_Previews.previews
+//        StateDiagramView_Previews.previews
+//        StopwatchView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
+//        HttpBinView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
+//        GitHubView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
+//        DownloaderView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
+//        VideoPlayerView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
+//        VideoPlayerMultiView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
+//        VideoDetectorView_Previews.previews
+//        ElemCellAutomaton_RootView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
+//        GameOfLife_RootView_Previews.makePreviews(environment: .live, isMultipleScreens: false)
+//        PhysicsRootView_Previews.makePreviews(state: .doublePendulum, environment: .live, isMultipleScreens: false)
+    }
+
+    var body: some View
+    {
+        _body.enableInjection()
+    }
+}


### PR DESCRIPTION
Restores SwiftUI hot-reloading via [Inject](https://github.com/krzysztofzablocki/Inject) for `Examples/SwiftUI-Gallery/Actomaton-Gallery`. Two independent fixes were needed; documenting each one because they're both silent failures (build & launch fine but injection just doesn't take effect).

### Inject 1.2.1 → 1.6.0

- 1.2.1 predates this project's move to Swift 6 strict concurrency; injection logs `💉 Injected type ...` but `objectWillChange` doesn't propagate, so SwiftUI never re-evaluates `body`. 1.6.0 fixes the publish path.
- Updated the inner `Package.resolved` under `Examples/SwiftUI-Gallery/Actomaton-Gallery.xcodeproj/...` to match the outer workspace pin.

### Hoist `Store` ownership to `DemoApp` (`@State`)

The original `AppView` constructed its `Store<...>` inside `init()`. Hot reload re-renders `InjectedAppView.body`, which constructed a fresh `AppView()` each time, which spun up a new `Store`. The previous `Store`'s deinit raced its in-flight Actomaton effects → `EXC_BAD_ACCESS` in `swift::RefCounts::incrementSlow` (address `0xd4…`, classic over-release marker).

- `DemoApp` now owns `@State private var store = AppView.makeStore()`. App-scope `@State` survives every injection.
- `AppView` becomes a thin renderer taking `let store`. Construction moved to `static AppView.makeStore()`.
- Side benefit: app state (counters / navigation) survives hot reload instead of resetting.

### `InjectedAppView` host (new file)

Both `@ObserveInjection` and `.enableInjection()` must live in the body of the view whose code you actually edit — applying `.enableInjection()` externally from a parent compiles fine but is silently no-op (the parent-level wrapper consumes the redraw signal; SwiftUI's structural diff then short-circuits propagation to the structurally-stable child since `store` is the same reference).

- New `InjectedAppView.swift` with `@ObserveInjection var inject` + `Group { … }.enableInjection()` in body, plus a screen-picker block (default `AppView(store:)` with commented `*_Previews.previews` alternatives for single-screen iteration).

### Setup

To verify locally:

1. Install [InjectionIII.app](https://github.com/johnno1962/InjectionIII/releases) (or InjectionNext) into `/Applications`.
2. Launch InjectionIII → Open Project → select this repo's `Package.swift` or the SwiftUI-Gallery workspace.
3. Run `Actomaton-Gallery` (Debug) on iOS Simulator. Console should print `💉 InjectionIII connected …`.
4. Edit `InjectedAppView.body` (e.g. uncomment `CounterView_Previews.previews`) and save — simulator updates without rebuild.
